### PR TITLE
fix(twland): send wl_keyboard.keymap fd via SCM_RIGHTS

### DIFF
--- a/userspace/apps/twland/src/main.rs
+++ b/userspace/apps/twland/src/main.rs
@@ -2,11 +2,17 @@ use core::ffi::c_void;
 use std::collections::{HashMap, VecDeque};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, ErrorKind};
-use std::mem::size_of;
 use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::ptr;
+
+mod wire;
+use wire::{
+    create_empty_memfd, parse_chunk, push_fixed, push_i32, push_u32, push_wayland_string,
+    read_i32, read_u32, read_wayland_string, recv_raw, send_message, OwnedFdRaw,
+    ReceivedMessage,
+};
 
 const RUNTIME_DIR: &str = "/run/user/0";
 const WAYLAND_SOCKET: &str = "/run/user/0/wayland-0";
@@ -84,12 +90,6 @@ const PROT_WRITE: i32 = 0x2;
 const MAP_SHARED: i32 = 0x01;
 const MAP_FAILED: *mut c_void = usize::MAX as *mut c_void;
 
-const SOL_SOCKET: i32 = 1;
-const SCM_RIGHTS: i32 = 1;
-const MSG_DONTWAIT: i32 = 0x40;
-const MAX_WIRE_CHUNK: usize = 64 * 1024;
-const MAX_CONTROL_BYTES: usize = 128;
-
 const GLOBALS: &[Global] = &[
     Global {
         name: 1,
@@ -124,34 +124,6 @@ const GLOBALS: &[Global] = &[
 ];
 
 #[repr(C)]
-struct Iovec {
-    iov_base: *mut c_void,
-    iov_len: usize,
-}
-
-#[repr(C)]
-struct Msghdr {
-    msg_name: *mut c_void,
-    msg_namelen: u32,
-    msg_iov: *mut Iovec,
-    msg_iovlen: i32,
-    __pad_iovlen: i32,
-    msg_control: *mut c_void,
-    msg_controllen: u32,
-    __pad_controllen: u32,
-    msg_flags: i32,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct Cmsghdr {
-    cmsg_len: u32,
-    __pad_len: i32,
-    cmsg_level: i32,
-    cmsg_type: i32,
-}
-
-#[repr(C)]
 #[derive(Default)]
 struct FbVarScreenInfo {
     xres: u32,
@@ -170,8 +142,6 @@ struct FbFixScreenInfo {
 }
 
 unsafe extern "C" {
-    fn sendmsg(fd: i32, msg: *const Msghdr, flags: i32) -> isize;
-    fn recvmsg(fd: i32, msg: *mut Msghdr, flags: i32) -> isize;
     fn sched_yield() -> i32;
     fn mmap(
         addr: *mut c_void,
@@ -184,19 +154,6 @@ unsafe extern "C" {
     fn munmap(addr: *mut c_void, len: usize) -> i32;
     fn close(fd: i32) -> i32;
     fn ioctl(fd: i32, request: u64, ...) -> i32;
-}
-
-#[derive(Debug, Clone, Copy)]
-struct WaylandHeader {
-    object_id: u32,
-    opcode: u16,
-    size: u16,
-}
-
-struct ReceivedMessage {
-    header: WaylandHeader,
-    payload: Vec<u8>,
-    fds: Vec<OwnedFdRaw>,
 }
 
 struct Client {
@@ -403,10 +360,6 @@ struct SoftwareOutput {
     pixels: *mut u8,
 }
 
-#[derive(Debug)]
-struct OwnedFdRaw {
-    fd: i32,
-}
 
 fn main() {
     if let Err(error) = run() {
@@ -2244,132 +2197,11 @@ fn recv_wayland_message(
         return Ok(Some(message));
     }
 
-    let mut data = vec![0_u8; MAX_WIRE_CHUNK];
-    let mut control = [0_u8; MAX_CONTROL_BYTES];
-    let mut iov = Iovec {
-        iov_base: data.as_mut_ptr().cast(),
-        iov_len: data.len(),
-    };
-    let mut msg = Msghdr {
-        msg_name: ptr::null_mut(),
-        msg_namelen: 0,
-        msg_iov: &mut iov,
-        msg_iovlen: 1,
-        __pad_iovlen: 0,
-        msg_control: control.as_mut_ptr().cast(),
-        msg_controllen: control.len() as u32,
-        __pad_controllen: 0,
-        msg_flags: 0,
-    };
-
-    // SAFETY: `msg` points to valid writable iovec/control buffers for the
-    // duration of the call, and the fd comes from a live UnixStream.
-    let received = unsafe { recvmsg(stream.as_raw_fd(), &mut msg, MSG_DONTWAIT) };
-    if received < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    if received == 0 {
+    let Some((bytes, fds)) = recv_raw(stream)? else {
         return Ok(None);
-    }
-
-    let fds = parse_received_fds(&control, msg.msg_controllen as usize);
-    parse_wire_chunk(&data[..received as usize], fds, &mut client.queued_messages)?;
+    };
+    parse_chunk(&bytes, fds, &mut client.queued_messages)?;
     Ok(client.queued_messages.pop_front())
-}
-
-fn parse_wire_chunk(
-    bytes: &[u8],
-    mut fds: Vec<OwnedFdRaw>,
-    queue: &mut VecDeque<ReceivedMessage>,
-) -> io::Result<()> {
-    let mut offset = 0usize;
-    let mut first = true;
-
-    while offset < bytes.len() {
-        if offset + 8 > bytes.len() {
-            return Err(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "truncated Wayland header",
-            ));
-        }
-
-        let header = parse_header(&bytes[offset..offset + 8]);
-        if header.size < 8 {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                format!("invalid message size {}", header.size),
-            ));
-        }
-
-        let end = offset + usize::from(header.size);
-        if end > bytes.len() {
-            return Err(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "truncated Wayland payload",
-            ));
-        }
-
-        let message_fds = if first {
-            first = false;
-            std::mem::take(&mut fds)
-        } else {
-            Vec::new()
-        };
-        queue.push_back(ReceivedMessage {
-            header,
-            payload: bytes[offset + 8..end].to_vec(),
-            fds: message_fds,
-        });
-        offset = end;
-    }
-
-    Ok(())
-}
-
-fn parse_received_fds(control: &[u8], controllen: usize) -> Vec<OwnedFdRaw> {
-    let mut fds = Vec::new();
-    if controllen < size_of::<Cmsghdr>() || controllen > control.len() {
-        return fds;
-    }
-
-    let mut offset = 0usize;
-    while offset + size_of::<Cmsghdr>() <= controllen {
-        // SAFETY: Bounds above guarantee enough bytes for an unaligned cmsghdr.
-        let cmsg = unsafe { ptr::read_unaligned(control.as_ptr().add(offset).cast::<Cmsghdr>()) };
-        let cmsg_len = cmsg.cmsg_len as usize;
-        if cmsg_len < size_of::<Cmsghdr>() || offset + cmsg_len > controllen {
-            break;
-        }
-
-        if cmsg.cmsg_level == SOL_SOCKET && cmsg.cmsg_type == SCM_RIGHTS {
-            let data_start = offset + size_of::<Cmsghdr>();
-            let data_len = cmsg_len - size_of::<Cmsghdr>();
-            for chunk in control[data_start..data_start + data_len].chunks_exact(size_of::<i32>()) {
-                let fd = i32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-                if fd >= 0 {
-                    fds.push(OwnedFdRaw { fd });
-                }
-            }
-        }
-
-        let next = cmsg_align(cmsg_len);
-        if next <= offset {
-            break;
-        }
-        offset += next;
-    }
-
-    fds
-}
-
-fn parse_header(raw: &[u8]) -> WaylandHeader {
-    let object_id = u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
-    let packed = u32::from_le_bytes([raw[4], raw[5], raw[6], raw[7]]);
-    WaylandHeader {
-        object_id,
-        opcode: (packed & 0xffff) as u16,
-        size: (packed >> 16) as u16,
-    }
 }
 
 fn send_registry_global(
@@ -2438,15 +2270,24 @@ fn send_seat_name(stream: &mut UnixStream, seat_id: u32, name: &str) -> io::Resu
 }
 
 fn send_keyboard_keymap(stream: &mut UnixStream, keyboard_id: u32) -> io::Result<()> {
+    // wl_keyboard.keymap(format, fd, size): the fd is a Wayland fd argument,
+    // so it travels out-of-band via SCM_RIGHTS and occupies zero payload bytes.
+    // The payload is just (format, size).  For NO_KEYMAP we still must pass a
+    // real (empty) file descriptor; an empty memfd satisfies the protocol
+    // without carrying any keymap data.  A later XKB stage should replace this
+    // with a memfd holding the compiled keymap string.
+    let keymap_fd = create_empty_memfd().map_err(|err| {
+        io::Error::new(
+            err.kind(),
+            format!("failed to create keymap memfd: {err}"),
+        )
+    })?;
+    let size = 0u32;
+
     let mut payload = Vec::new();
     push_u32(&mut payload, WL_KEYBOARD_KEYMAP_FORMAT_NO_KEYMAP);
-    // wl_keyboard.keymap is (format, fd, size).  This first input milestone uses
-    // format=NO_KEYMAP, so there is no real keymap fd to pass yet; keep the fd
-    // slot as 0 for Twilight's minimal test clients and size as 0.  A later XKB
-    // stage should send a memfd through SCM_RIGHTS here.
-    push_u32(&mut payload, 0);
-    push_u32(&mut payload, 0);
-    send_message(stream, keyboard_id, WL_KEYBOARD_KEYMAP, &payload)
+    push_u32(&mut payload, size);
+    wire::send_message_with_fds(stream, keyboard_id, WL_KEYBOARD_KEYMAP, &payload, &[keymap_fd.as_raw()])
 }
 
 fn send_pointer_enter(
@@ -2544,65 +2385,6 @@ fn send_keyboard_key(
     push_u32(&mut payload, keycode);
     push_u32(&mut payload, state);
     send_message(stream, keyboard_id, WL_KEYBOARD_KEY, &payload)
-}
-
-fn send_message(
-    stream: &mut UnixStream,
-    object_id: u32,
-    opcode: u16,
-    payload: &[u8],
-) -> io::Result<()> {
-    let size = 8_usize
-        .checked_add(payload.len())
-        .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "message too large"))?;
-    if size > u16::MAX as usize {
-        return Err(io::Error::new(ErrorKind::InvalidInput, "message too large"));
-    }
-
-    let mut message = Vec::with_capacity(size);
-    push_u32(&mut message, object_id);
-    push_u32(&mut message, ((size as u32) << 16) | u32::from(opcode));
-    message.extend_from_slice(payload);
-    send_wayland_bytes(stream, &message)
-}
-
-fn send_wayland_bytes(stream: &mut UnixStream, message: &[u8]) -> io::Result<()> {
-    let mut offset = 0;
-    while offset < message.len() {
-        let mut iov = Iovec {
-            // sendmsg does not mutate the buffer, but musl's iovec field is a
-            // mutable pointer in C. Keep the cast local to this syscall wrapper.
-            iov_base: message[offset..].as_ptr() as *mut c_void,
-            iov_len: message.len() - offset,
-        };
-        let hdr = Msghdr {
-            msg_name: ptr::null_mut(),
-            msg_namelen: 0,
-            msg_iov: &mut iov,
-            msg_iovlen: 1,
-            __pad_iovlen: 0,
-            msg_control: ptr::null_mut(),
-            msg_controllen: 0,
-            __pad_controllen: 0,
-            msg_flags: 0,
-        };
-
-        // SAFETY: `hdr` and its single iovec point at the immutable `message`
-        // slice for the duration of the syscall. `msg_name` and control are
-        // null because this is a connected AF_UNIX stream.
-        let sent = unsafe { sendmsg(stream.as_raw_fd(), &hdr, 0) };
-        if sent < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        if sent == 0 {
-            return Err(io::Error::new(
-                ErrorKind::WriteZero,
-                "sendmsg wrote zero bytes",
-            ));
-        }
-        offset += sent as usize;
-    }
-    Ok(())
 }
 
 fn blit_shm_buffer_to_output(
@@ -2884,24 +2666,6 @@ impl Drop for ShmPoolState {
     }
 }
 
-impl OwnedFdRaw {
-    fn into_raw(mut self) -> i32 {
-        let fd = self.fd;
-        self.fd = -1;
-        fd
-    }
-}
-
-impl Drop for OwnedFdRaw {
-    fn drop(&mut self) {
-        if self.fd >= 0 {
-            // SAFETY: fd is owned by this wrapper unless it was moved out using
-            // into_raw, in which case it is set to -1.
-            let _ = unsafe { close(self.fd) };
-            self.fd = -1;
-        }
-    }
-}
 
 impl Rect {
     fn union(self, other: Rect) -> Rect {
@@ -2922,75 +2686,4 @@ impl Rect {
             height: y1.saturating_sub(y0),
         }
     }
-}
-
-fn read_u32(bytes: &[u8], offset: usize) -> io::Result<u32> {
-    let raw = bytes
-        .get(offset..offset + 4)
-        .ok_or_else(|| io::Error::new(ErrorKind::UnexpectedEof, "missing u32 argument"))?;
-    Ok(u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]))
-}
-
-fn read_i32(bytes: &[u8], offset: usize) -> io::Result<i32> {
-    Ok(read_u32(bytes, offset)? as i32)
-}
-
-fn read_wayland_string(bytes: &[u8], offset: usize) -> io::Result<(String, usize)> {
-    let length = read_u32(bytes, offset)? as usize;
-    if length == 0 {
-        return Ok((String::new(), align4(offset + 4)));
-    }
-
-    let start = offset + 4;
-    let end = start
-        .checked_add(length)
-        .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "string length overflow"))?;
-    let raw = bytes
-        .get(start..end)
-        .ok_or_else(|| io::Error::new(ErrorKind::UnexpectedEof, "truncated string argument"))?;
-    if raw.last() != Some(&0) {
-        return Err(io::Error::new(
-            ErrorKind::InvalidData,
-            "string argument is not NUL-terminated",
-        ));
-    }
-
-    let value = std::str::from_utf8(&raw[..raw.len() - 1])
-        .map_err(|_| io::Error::new(ErrorKind::InvalidData, "string argument is not UTF-8"))?
-        .to_string();
-    Ok((value, align4(end)))
-}
-
-fn push_u32(bytes: &mut Vec<u8>, value: u32) {
-    bytes.extend_from_slice(&value.to_le_bytes());
-}
-
-fn push_i32(bytes: &mut Vec<u8>, value: i32) {
-    bytes.extend_from_slice(&value.to_le_bytes());
-}
-
-fn push_fixed(bytes: &mut Vec<u8>, value: i32) {
-    push_i32(bytes, value.saturating_mul(256));
-}
-
-fn push_wayland_string(bytes: &mut Vec<u8>, value: &str) {
-    let length = value.len() + 1;
-    push_u32(bytes, length as u32);
-    bytes.extend_from_slice(value.as_bytes());
-    bytes.push(0);
-    while bytes.len() % 4 != 0 {
-        bytes.push(0);
-    }
-}
-
-fn align4(value: usize) -> usize {
-    (value + 3) & !3
-}
-
-fn cmsg_align(value: usize) -> usize {
-    align4_to(value, size_of::<usize>())
-}
-
-fn align4_to(value: usize, alignment: usize) -> usize {
-    (value + alignment - 1) & !(alignment - 1)
 }

--- a/userspace/apps/twland/src/main.rs
+++ b/userspace/apps/twland/src/main.rs
@@ -167,6 +167,14 @@ struct Client {
     xdg_surfaces: HashMap<u32, XdgSurfaceState>,
     xdg_toplevels: HashMap<u32, XdgToplevelState>,
     queued_messages: VecDeque<ReceivedMessage>,
+    /// Bytes from a read that did not contain a complete final frame; the next
+    /// read appends to this and framing resumes.  AF_UNIX streams split frames
+    /// at arbitrary byte boundaries, so a frame can span two reads.
+    residual: Vec<u8>,
+    /// Out-of-band file descriptors received via `SCM_RIGHTS`, in stream order.
+    /// A single read may carry fds for several batched requests, so each
+    /// fd-carrying request handler pops exactly the fds its signature requires.
+    pending_fds: VecDeque<OwnedFdRaw>,
     input: InputState,
     compositor: CompositorState,
     next_serial: u32,
@@ -500,6 +508,8 @@ impl Client {
             xdg_surfaces: HashMap::new(),
             xdg_toplevels: HashMap::new(),
             queued_messages: VecDeque::new(),
+            residual: Vec::new(),
+            pending_fds: VecDeque::new(),
             input: InputState {
                 pointer_x: 80,
                 pointer_y: 80,
@@ -636,7 +646,7 @@ fn dispatch_request(
             handle_compositor_create_surface(client, &message.payload)
         }
         (WaylandObjectKind::Shm, WL_SHM_CREATE_POOL) => {
-            handle_shm_create_pool(client, message.payload, message.fds)
+            handle_shm_create_pool(client, message.payload)
         }
         (WaylandObjectKind::Seat, WL_SEAT_GET_POINTER) => {
             handle_seat_get_pointer(client, message.header.object_id, &message.payload)
@@ -875,11 +885,7 @@ fn handle_seat_get_keyboard(
     Ok(())
 }
 
-fn handle_shm_create_pool(
-    client: &mut Client,
-    payload: Vec<u8>,
-    mut fds: Vec<OwnedFdRaw>,
-) -> io::Result<()> {
+fn handle_shm_create_pool(client: &mut Client, payload: Vec<u8>) -> io::Result<()> {
     let pool_id = read_u32(&payload, 0)?;
     let size = read_i32(&payload, 4)?;
     if size <= 0 {
@@ -889,14 +895,15 @@ fn handle_shm_create_pool(
         ));
     }
 
-    if fds.is_empty() {
-        return Err(io::Error::new(
+    // wl_shm.create_pool carries exactly one fd argument; pop it from the
+    // per-client FIFO in stream order.
+    let fd = client.pending_fds.pop_front().ok_or_else(|| {
+        io::Error::new(
             ErrorKind::InvalidData,
             "wl_shm.create_pool requires one SCM_RIGHTS fd",
-        ));
-    }
-
-    let fd = fds.remove(0).into_raw();
+        )
+    })?;
+    let fd = fd.into_raw();
     let size = size as usize;
     let mapped = unsafe_mmap_shm(fd, size)?;
 
@@ -2200,7 +2207,16 @@ fn recv_wayland_message(
     let Some((bytes, fds)) = recv_raw(stream)? else {
         return Ok(None);
     };
-    parse_chunk(&bytes, fds, &mut client.queued_messages)?;
+
+    // Fds from this read go into the per-client FIFO; request handlers pop them
+    // in stream order as their signatures require.
+    client.pending_fds.extend(fds);
+
+    // Append to any leftover from a previous read, frame as many complete
+    // messages as are available, then retain the unconsumed tail.
+    client.residual.extend_from_slice(&bytes);
+    let consumed = parse_chunk(&client.residual, &mut client.queued_messages)?;
+    client.residual.drain(..consumed);
     Ok(client.queued_messages.pop_front())
 }
 

--- a/userspace/apps/twland/src/wire.rs
+++ b/userspace/apps/twland/src/wire.rs
@@ -39,21 +39,18 @@ struct Msghdr {
     msg_name: *mut c_void,
     msg_namelen: u32,
     msg_iov: *mut Iovec,
-    msg_iovlen: i32,
-    __pad_iovlen: i32,
+    msg_iovlen: usize,
     msg_control: *mut c_void,
-    msg_controllen: u32,
-    __pad_controllen: u32,
+    msg_controllen: usize,
     msg_flags: i32,
 }
 
-/// `cmsghdr` with explicit padding so `cmsg_len` occupies a full `size_t` on
-/// 64-bit, matching the kernel's `struct cmsghdr` layout.
+/// `cmsghdr` matching the kernel's `struct cmsghdr` layout: `cmsg_len` is
+/// `size_t`, so on 64-bit targets it occupies a full 8 bytes with no padding.
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct Cmsghdr {
-    cmsg_len: u32,
-    __pad_len: i32,
+    cmsg_len: usize,
     cmsg_level: i32,
     cmsg_type: i32,
 }
@@ -72,12 +69,12 @@ pub struct WaylandHeader {
     pub size: u16,
 }
 
-/// One decoded Wayland message: header, payload bytes, and any fds received
-/// alongside it via `SCM_RIGHTS`.
+/// One decoded Wayland message: header and payload bytes.  File descriptors
+/// for fd-carrying requests are not attached here; they live in a per-client
+/// FIFO and are popped by the request handler that needs them.
 pub struct ReceivedMessage {
     pub header: WaylandHeader,
     pub payload: Vec<u8>,
-    pub fds: Vec<OwnedFdRaw>,
 }
 
 /// An owned raw file descriptor that is closed on drop unless moved out with
@@ -207,10 +204,8 @@ fn send_bytes(stream: &mut UnixStream, message: &[u8], fds: &[i32]) -> io::Resul
             msg_namelen: 0,
             msg_iov: &mut iov,
             msg_iovlen: 1,
-            __pad_iovlen: 0,
             msg_control: control_ptr,
             msg_controllen: control_len,
-            __pad_controllen: 0,
             msg_flags: 0,
         };
 
@@ -237,7 +232,7 @@ fn send_bytes(stream: &mut UnixStream, message: &[u8], fds: &[i32]) -> io::Resul
 
 /// Build a single `SCM_RIGHTS` control message carrying `fds` into `control`
 /// and return the aligned length to set as `msg_controllen`.
-fn build_scm_rights(control: &mut [u8; MAX_CONTROL_BYTES], fds: &[i32]) -> io::Result<u32> {
+fn build_scm_rights(control: &mut [u8; MAX_CONTROL_BYTES], fds: &[i32]) -> io::Result<usize> {
     let header_len = size_of::<Cmsghdr>();
     let data_len = size_of_val(fds);
     let cmsg_len = header_len + data_len;
@@ -250,8 +245,7 @@ fn build_scm_rights(control: &mut [u8; MAX_CONTROL_BYTES], fds: &[i32]) -> io::R
     }
 
     let cmsg = Cmsghdr {
-        cmsg_len: cmsg_len as u32,
-        __pad_len: 0,
+        cmsg_len,
         cmsg_level: SOL_SOCKET,
         cmsg_type: SCM_RIGHTS,
     };
@@ -268,7 +262,7 @@ fn build_scm_rights(control: &mut [u8; MAX_CONTROL_BYTES], fds: &[i32]) -> io::R
         *byte = 0;
     }
 
-    Ok(aligned as u32)
+    Ok(aligned)
 }
 
 /// Read one chunk from the socket.  Returns `Ok(None)` on EOF, `Err(WouldBlock)`
@@ -286,10 +280,8 @@ pub fn recv_raw(stream: &mut UnixStream) -> io::Result<Option<(Vec<u8>, Vec<Owne
         msg_namelen: 0,
         msg_iov: &mut iov,
         msg_iovlen: 1,
-        __pad_iovlen: 0,
         msg_control: control.as_mut_ptr().cast(),
-        msg_controllen: control.len() as u32,
-        __pad_controllen: 0,
+        msg_controllen: control.len(),
         msg_flags: 0,
     };
 
@@ -303,30 +295,41 @@ pub fn recv_raw(stream: &mut UnixStream) -> io::Result<Option<(Vec<u8>, Vec<Owne
         return Ok(None);
     }
 
-    let fds = parse_received_fds(&control, msg.msg_controllen as usize);
+    // If the control buffer was too small for the ancillary data, the kernel
+    // sets MSG_CTRUNC and drops the excess descriptors.  Treat that as a
+    // transport error rather than silently returning fewer fds than sent.
+    const MSG_CTRUNC: i32 = 0x08;
+    if msg.msg_flags & MSG_CTRUNC != 0 {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "ancillary data truncated; control buffer too small",
+        ));
+    }
+
+    let fds = parse_received_fds(&control, msg.msg_controllen);
     data.truncate(received as usize);
     Ok(Some((data, fds)))
 }
 
-/// Decode a received chunk into one or more queued messages.  All fds from the
-/// chunk attach to the first message, matching how clients send fd-carrying
-/// requests on the stream.
+/// Decode complete Wayland messages from the front of `bytes` into `queue`.
+///
+/// Returns the number of bytes consumed.  A frame whose header or payload is
+/// only partially present (because the stream split it across reads) is left
+/// untouched: the caller retains the unconsumed tail and appends the next
+/// chunk to it.  This never errors on a short buffer — only on a structurally
+/// invalid header (`size < 8`).
+///
+/// File descriptors are not attached here.  Wayland fd arguments are
+/// out-of-band and a single `recvmsg` may carry fds for several batched
+/// requests, so the caller owns a per-client fd FIFO and each request handler
+/// pops exactly the fds its signature requires.
 pub fn parse_chunk(
     bytes: &[u8],
-    mut fds: Vec<OwnedFdRaw>,
     queue: &mut VecDeque<ReceivedMessage>,
-) -> io::Result<()> {
+) -> io::Result<usize> {
     let mut offset = 0usize;
-    let mut first = true;
 
-    while offset < bytes.len() {
-        if offset + 8 > bytes.len() {
-            return Err(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "truncated Wayland header",
-            ));
-        }
-
+    while offset + 8 <= bytes.len() {
         let header = parse_header(&bytes[offset..offset + 8]);
         if header.size < 8 {
             return Err(io::Error::new(
@@ -337,27 +340,19 @@ pub fn parse_chunk(
 
         let end = offset + usize::from(header.size);
         if end > bytes.len() {
-            return Err(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "truncated Wayland payload",
-            ));
+            // Payload (or this is the last partial frame) not fully received
+            // yet; wait for more bytes from the next read.
+            break;
         }
 
-        let message_fds = if first {
-            first = false;
-            std::mem::take(&mut fds)
-        } else {
-            Vec::new()
-        };
         queue.push_back(ReceivedMessage {
             header,
             payload: bytes[offset + 8..end].to_vec(),
-            fds: message_fds,
         });
         offset = end;
     }
 
-    Ok(())
+    Ok(offset)
 }
 
 fn parse_received_fds(control: &[u8], controllen: usize) -> Vec<OwnedFdRaw> {
@@ -370,7 +365,7 @@ fn parse_received_fds(control: &[u8], controllen: usize) -> Vec<OwnedFdRaw> {
     while offset + size_of::<Cmsghdr>() <= controllen {
         // SAFETY: Bounds above guarantee enough bytes for an unaligned cmsghdr.
         let cmsg = unsafe { ptr::read_unaligned(control.as_ptr().add(offset).cast::<Cmsghdr>()) };
-        let cmsg_len = cmsg.cmsg_len as usize;
+        let cmsg_len = cmsg.cmsg_len;
         if cmsg_len < size_of::<Cmsghdr>() || offset + cmsg_len > controllen {
             break;
         }
@@ -458,13 +453,15 @@ pub fn push_fixed(bytes: &mut Vec<u8>, value: i32) {
 }
 
 pub fn push_wayland_string(bytes: &mut Vec<u8>, value: &str) {
+    // A Wayland string is: u32 length (including NUL), the bytes, a NUL
+    // terminator, then NUL padding to a 4-byte boundary.  Compute the padding
+    // from the field length so it is independent of the caller's buffer state.
     let length = value.len() + 1;
     push_u32(bytes, length as u32);
     bytes.extend_from_slice(value.as_bytes());
     bytes.push(0);
-    while !bytes.len().is_multiple_of(4) {
-        bytes.push(0);
-    }
+    let padding = align4(length) - length;
+    bytes.resize(bytes.len() + padding, 0);
 }
 
 fn align4(value: usize) -> usize {

--- a/userspace/apps/twland/src/wire.rs
+++ b/userspace/apps/twland/src/wire.rs
@@ -1,0 +1,480 @@
+//! Wayland wire-protocol layer for twland.
+//!
+//! This module owns the byte-level framing of the Wayland stream: message
+//! headers, the argument codec, SCM_RIGHTS file-descriptor passing, and the
+//! raw sendmsg/recvmsg syscalls.  Everything above this layer speaks in terms
+//! of [`ReceivedMessage`] values and [`send_message`] / [`send_message_with_fds`]
+//! calls and never touches a cmsghdr.
+//!
+//! The fd-passing path here is the fix for the `wl_keyboard.keymap` bug where
+//! the fd argument was being serialized into the payload as a `u32`.  Wayland
+//! fd arguments travel out-of-band via `SCM_RIGHTS` and occupy zero payload
+//! bytes; [`send_message_with_fds`] is the only correct way to emit them.
+
+use core::ffi::c_void;
+use std::collections::VecDeque;
+use std::io::{self, ErrorKind};
+use std::mem::size_of;
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::ptr;
+
+/// Maximum bytes read from the socket in a single `recvmsg`.
+const MAX_WIRE_CHUNK: usize = 64 * 1024;
+/// Control-message buffer for received `SCM_RIGHTS` fds.
+const MAX_CONTROL_BYTES: usize = 128;
+
+const SOL_SOCKET: i32 = 1;
+const SCM_RIGHTS: i32 = 1;
+const MSG_DONTWAIT: i32 = 0x40;
+
+#[repr(C)]
+struct Iovec {
+    iov_base: *mut c_void,
+    iov_len: usize,
+}
+
+#[repr(C)]
+struct Msghdr {
+    msg_name: *mut c_void,
+    msg_namelen: u32,
+    msg_iov: *mut Iovec,
+    msg_iovlen: i32,
+    __pad_iovlen: i32,
+    msg_control: *mut c_void,
+    msg_controllen: u32,
+    __pad_controllen: u32,
+    msg_flags: i32,
+}
+
+/// `cmsghdr` with explicit padding so `cmsg_len` occupies a full `size_t` on
+/// 64-bit, matching the kernel's `struct cmsghdr` layout.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Cmsghdr {
+    cmsg_len: u32,
+    __pad_len: i32,
+    cmsg_level: i32,
+    cmsg_type: i32,
+}
+
+unsafe extern "C" {
+    fn sendmsg(fd: i32, msg: *const Msghdr, flags: i32) -> isize;
+    fn recvmsg(fd: i32, msg: *mut Msghdr, flags: i32) -> isize;
+    fn memfd_create(name: *const u8, flags: u32) -> i32;
+    fn close(fd: i32) -> i32;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct WaylandHeader {
+    pub object_id: u32,
+    pub opcode: u16,
+    pub size: u16,
+}
+
+/// One decoded Wayland message: header, payload bytes, and any fds received
+/// alongside it via `SCM_RIGHTS`.
+pub struct ReceivedMessage {
+    pub header: WaylandHeader,
+    pub payload: Vec<u8>,
+    pub fds: Vec<OwnedFdRaw>,
+}
+
+/// An owned raw file descriptor that is closed on drop unless moved out with
+/// [`OwnedFdRaw::into_raw`].
+#[derive(Debug)]
+pub struct OwnedFdRaw {
+    fd: i32,
+}
+
+impl OwnedFdRaw {
+    /// Wrap a raw open file descriptor.  The wrapper closes it on drop unless
+    /// moved out with [`OwnedFdRaw::into_raw`].
+    pub fn new(fd: i32) -> Self {
+        Self { fd }
+    }
+
+    /// The underlying raw file descriptor.
+    pub fn as_raw(&self) -> i32 {
+        self.fd
+    }
+
+    pub fn into_raw(mut self) -> i32 {
+        let fd = self.fd;
+        self.fd = -1;
+        fd
+    }
+}
+
+impl Drop for OwnedFdRaw {
+    fn drop(&mut self) {
+        if self.fd >= 0 {
+            // SAFETY: fd is owned by this wrapper unless moved out via into_raw,
+            // in which case it is set to -1.
+            let _ = unsafe { close(self.fd) };
+            self.fd = -1;
+        }
+    }
+}
+
+/// Create an empty, read/write memfd wrapped in [`OwnedFdRaw`].  Used for
+/// `wl_keyboard.keymap` with `WL_KEYBOARD_KEYMAP_FORMAT_NO_KEYMAP`, where the
+/// protocol still carries a file descriptor even though there is no keymap
+/// data.  The wrapper closes the local copy after the kernel duplicates the
+/// fd into the client's socket buffer.
+pub fn create_empty_memfd() -> io::Result<OwnedFdRaw> {
+    const MFD_CLOEXEC: u32 = 0x0001;
+    let name = b"twland-keymap\0";
+    // SAFETY: `memfd_create` is provided by musl (wrapping Twilight syscall
+    // 319).  `name` is a NUL-terminated static slice and `MFD_CLOEXEC` is an
+    // allowed flag.
+    let fd = unsafe { memfd_create(name.as_ptr(), MFD_CLOEXEC) };
+    if fd < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(OwnedFdRaw::new(fd))
+    }
+}
+
+/// Send a Wayland event with no file descriptors.
+pub fn send_message(
+    stream: &mut UnixStream,
+    object_id: u32,
+    opcode: u16,
+    payload: &[u8],
+) -> io::Result<()> {
+    let message = encode_message(object_id, opcode, payload)?;
+    send_bytes(stream, &message, &[])
+}
+
+/// Send a Wayland event carrying file descriptors via `SCM_RIGHTS`.
+///
+/// The fds are attached to the first byte of the message and consumed by the
+/// kernel on the first `sendmsg`; if the message is larger than what a single
+/// `sendmsg` accepts, remaining bytes are flushed in further sends with no
+/// control message.  This matches the Wayland stream contract: fd arguments
+/// occupy zero payload bytes and are delivered with the message prefix.
+pub fn send_message_with_fds(
+    stream: &mut UnixStream,
+    object_id: u32,
+    opcode: u16,
+    payload: &[u8],
+    fds: &[i32],
+) -> io::Result<()> {
+    let message = encode_message(object_id, opcode, payload)?;
+    send_bytes(stream, &message, fds)
+}
+
+fn encode_message(object_id: u32, opcode: u16, payload: &[u8]) -> io::Result<Vec<u8>> {
+    let size = 8_usize
+        .checked_add(payload.len())
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "message too large"))?;
+    if size > u16::MAX as usize {
+        return Err(io::Error::new(ErrorKind::InvalidInput, "message too large"));
+    }
+
+    let mut message = Vec::with_capacity(size);
+    push_u32(&mut message, object_id);
+    push_u32(&mut message, ((size as u32) << 16) | u32::from(opcode));
+    message.extend_from_slice(payload);
+    Ok(message)
+}
+
+fn send_bytes(stream: &mut UnixStream, message: &[u8], fds: &[i32]) -> io::Result<()> {
+    let mut offset = 0;
+    // Fds attach to the first byte and are consumed by the first successful
+    // sendmsg; subsequent iterations send plain bytes.
+    let mut pending_fds = fds;
+
+    while offset < message.len() {
+        let mut iov = Iovec {
+            // sendmsg does not mutate the buffer, but musl's iovec field is a
+            // mutable pointer in C.  Keep the cast local to this syscall wrapper.
+            iov_base: message[offset..].as_ptr() as *mut c_void,
+            iov_len: message.len() - offset,
+        };
+
+        let mut control = [0u8; MAX_CONTROL_BYTES];
+        let (control_ptr, control_len) = if pending_fds.is_empty() {
+            (ptr::null_mut(), 0)
+        } else {
+            let len = build_scm_rights(&mut control, pending_fds)?;
+            (control.as_mut_ptr().cast(), len)
+        };
+
+        let hdr = Msghdr {
+            msg_name: ptr::null_mut(),
+            msg_namelen: 0,
+            msg_iov: &mut iov,
+            msg_iovlen: 1,
+            __pad_iovlen: 0,
+            msg_control: control_ptr,
+            msg_controllen: control_len,
+            __pad_controllen: 0,
+            msg_flags: 0,
+        };
+
+        // SAFETY: `hdr` and its single iovec point at the immutable `message`
+        // slice for the duration of the syscall.  The control buffer, when
+        // present, is a valid stack array for the call's duration.  This is a
+        // connected AF_UNIX stream, so msg_name and control-without-fds are null.
+        let sent = unsafe { sendmsg(stream.as_raw_fd(), &hdr, 0) };
+        if sent < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if sent == 0 {
+            return Err(io::Error::new(
+                ErrorKind::WriteZero,
+                "sendmsg wrote zero bytes",
+            ));
+        }
+        offset += sent as usize;
+        pending_fds = &[];
+    }
+
+    Ok(())
+}
+
+/// Build a single `SCM_RIGHTS` control message carrying `fds` into `control`
+/// and return the aligned length to set as `msg_controllen`.
+fn build_scm_rights(control: &mut [u8; MAX_CONTROL_BYTES], fds: &[i32]) -> io::Result<u32> {
+    let header_len = size_of::<Cmsghdr>();
+    let data_len = size_of_val(fds);
+    let cmsg_len = header_len + data_len;
+    let aligned = cmsg_align(cmsg_len);
+    if aligned > control.len() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "too many fds for control buffer",
+        ));
+    }
+
+    let cmsg = Cmsghdr {
+        cmsg_len: cmsg_len as u32,
+        __pad_len: 0,
+        cmsg_level: SOL_SOCKET,
+        cmsg_type: SCM_RIGHTS,
+    };
+    // SAFETY: Cmsghdr is repr(C) and the header_len bytes fit in the buffer.
+    unsafe { ptr::write_unaligned(control.as_mut_ptr().cast::<Cmsghdr>(), cmsg) };
+
+    let data_start = header_len;
+    for (i, fd) in fds.iter().enumerate() {
+        let off = data_start + i * size_of::<i32>();
+        control[off..off + 4].copy_from_slice(&fd.to_ne_bytes());
+    }
+    // Zero-fill trailing alignment padding so the kernel does not read garbage.
+    for byte in &mut control[cmsg_len..aligned] {
+        *byte = 0;
+    }
+
+    Ok(aligned as u32)
+}
+
+/// Read one chunk from the socket.  Returns `Ok(None)` on EOF, `Err(WouldBlock)`
+/// when no data is ready, or `Ok(Some((bytes, fds)))` with the received bytes
+/// and any `SCM_RIGHTS` fds.
+pub fn recv_raw(stream: &mut UnixStream) -> io::Result<Option<(Vec<u8>, Vec<OwnedFdRaw>)>> {
+    let mut data = vec![0u8; MAX_WIRE_CHUNK];
+    let mut control = [0u8; MAX_CONTROL_BYTES];
+    let mut iov = Iovec {
+        iov_base: data.as_mut_ptr().cast(),
+        iov_len: data.len(),
+    };
+    let mut msg = Msghdr {
+        msg_name: ptr::null_mut(),
+        msg_namelen: 0,
+        msg_iov: &mut iov,
+        msg_iovlen: 1,
+        __pad_iovlen: 0,
+        msg_control: control.as_mut_ptr().cast(),
+        msg_controllen: control.len() as u32,
+        __pad_controllen: 0,
+        msg_flags: 0,
+    };
+
+    // SAFETY: `msg` points at valid writable iovec/control buffers for the
+    // duration of the call, and the fd comes from a live UnixStream.
+    let received = unsafe { recvmsg(stream.as_raw_fd(), &mut msg, MSG_DONTWAIT) };
+    if received < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if received == 0 {
+        return Ok(None);
+    }
+
+    let fds = parse_received_fds(&control, msg.msg_controllen as usize);
+    data.truncate(received as usize);
+    Ok(Some((data, fds)))
+}
+
+/// Decode a received chunk into one or more queued messages.  All fds from the
+/// chunk attach to the first message, matching how clients send fd-carrying
+/// requests on the stream.
+pub fn parse_chunk(
+    bytes: &[u8],
+    mut fds: Vec<OwnedFdRaw>,
+    queue: &mut VecDeque<ReceivedMessage>,
+) -> io::Result<()> {
+    let mut offset = 0usize;
+    let mut first = true;
+
+    while offset < bytes.len() {
+        if offset + 8 > bytes.len() {
+            return Err(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "truncated Wayland header",
+            ));
+        }
+
+        let header = parse_header(&bytes[offset..offset + 8]);
+        if header.size < 8 {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("invalid message size {}", header.size),
+            ));
+        }
+
+        let end = offset + usize::from(header.size);
+        if end > bytes.len() {
+            return Err(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "truncated Wayland payload",
+            ));
+        }
+
+        let message_fds = if first {
+            first = false;
+            std::mem::take(&mut fds)
+        } else {
+            Vec::new()
+        };
+        queue.push_back(ReceivedMessage {
+            header,
+            payload: bytes[offset + 8..end].to_vec(),
+            fds: message_fds,
+        });
+        offset = end;
+    }
+
+    Ok(())
+}
+
+fn parse_received_fds(control: &[u8], controllen: usize) -> Vec<OwnedFdRaw> {
+    let mut fds = Vec::new();
+    if controllen < size_of::<Cmsghdr>() || controllen > control.len() {
+        return fds;
+    }
+
+    let mut offset = 0usize;
+    while offset + size_of::<Cmsghdr>() <= controllen {
+        // SAFETY: Bounds above guarantee enough bytes for an unaligned cmsghdr.
+        let cmsg = unsafe { ptr::read_unaligned(control.as_ptr().add(offset).cast::<Cmsghdr>()) };
+        let cmsg_len = cmsg.cmsg_len as usize;
+        if cmsg_len < size_of::<Cmsghdr>() || offset + cmsg_len > controllen {
+            break;
+        }
+
+        if cmsg.cmsg_level == SOL_SOCKET && cmsg.cmsg_type == SCM_RIGHTS {
+            let data_start = offset + size_of::<Cmsghdr>();
+            let data_len = cmsg_len - size_of::<Cmsghdr>();
+            for chunk in control[data_start..data_start + data_len].chunks_exact(size_of::<i32>()) {
+                let fd = i32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                if fd >= 0 {
+                    fds.push(OwnedFdRaw { fd });
+                }
+            }
+        }
+
+        let next = cmsg_align(cmsg_len);
+        if next <= offset {
+            break;
+        }
+        offset += next;
+    }
+
+    fds
+}
+
+fn parse_header(raw: &[u8]) -> WaylandHeader {
+    let object_id = u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
+    let packed = u32::from_le_bytes([raw[4], raw[5], raw[6], raw[7]]);
+    WaylandHeader {
+        object_id,
+        opcode: (packed & 0xffff) as u16,
+        size: (packed >> 16) as u16,
+    }
+}
+
+// --- argument codec -------------------------------------------------------
+
+pub fn read_u32(bytes: &[u8], offset: usize) -> io::Result<u32> {
+    let raw = bytes
+        .get(offset..offset + 4)
+        .ok_or_else(|| io::Error::new(ErrorKind::UnexpectedEof, "missing u32 argument"))?;
+    Ok(u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]))
+}
+
+pub fn read_i32(bytes: &[u8], offset: usize) -> io::Result<i32> {
+    Ok(read_u32(bytes, offset)? as i32)
+}
+
+pub fn read_wayland_string(bytes: &[u8], offset: usize) -> io::Result<(String, usize)> {
+    let length = read_u32(bytes, offset)? as usize;
+    if length == 0 {
+        return Ok((String::new(), align4(offset + 4)));
+    }
+
+    let start = offset + 4;
+    let end = start
+        .checked_add(length)
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "string length overflow"))?;
+    let raw = bytes
+        .get(start..end)
+        .ok_or_else(|| io::Error::new(ErrorKind::UnexpectedEof, "truncated string argument"))?;
+    if raw.last() != Some(&0) {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "string argument is not NUL-terminated",
+        ));
+    }
+
+    let value = std::str::from_utf8(&raw[..raw.len() - 1])
+        .map_err(|_| io::Error::new(ErrorKind::InvalidData, "string argument is not UTF-8"))?
+        .to_string();
+    Ok((value, align4(end)))
+}
+
+pub fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+pub fn push_i32(bytes: &mut Vec<u8>, value: i32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+pub fn push_fixed(bytes: &mut Vec<u8>, value: i32) {
+    push_i32(bytes, value.saturating_mul(256));
+}
+
+pub fn push_wayland_string(bytes: &mut Vec<u8>, value: &str) {
+    let length = value.len() + 1;
+    push_u32(bytes, length as u32);
+    bytes.extend_from_slice(value.as_bytes());
+    bytes.push(0);
+    while !bytes.len().is_multiple_of(4) {
+        bytes.push(0);
+    }
+}
+
+fn align4(value: usize) -> usize {
+    (value + 3) & !3
+}
+
+fn cmsg_align(value: usize) -> usize {
+    align4_to(value, size_of::<usize>())
+}
+
+fn align4_to(value: usize, alignment: usize) -> usize {
+    (value + alignment - 1) & !(alignment - 1)
+}


### PR DESCRIPTION
## Summary

Fixes #39 — `wl_keyboard.keymap` was corrupting the Wayland wire format and disconnecting every libwayland client that bound a keyboard.

## Root cause

The keymap event's `fd` argument was being serialized into the message payload as a bogus `u32`:

```rust
push_u32(&mut payload, WL_KEYBOARD_KEYMAP_FORMAT_NO_KEYMAP);
push_u32(&mut payload, 0);   // ← fd is NOT a payload field
push_u32(&mut payload, 0);    // size
```

`wl_keyboard.keymap(format, fd, size)` carries the `fd` out-of-band via `SCM_RIGHTS` — it occupies **zero** payload bytes. The bogus payload (12 bytes instead of 8) plus a missing ancillary fd caused libwayland to raise a protocol error and tear down the connection on every `wl_seat.get_keyboard`.

The keymap bug was the symptom. The root cause was that **the send path had no SCM_RIGHTS fd-passing capability at all** — `send_message` only sent bytes.

## Changes

**1. New wire-protocol layer — `src/wire.rs` (480 lines)**

Owns everything byte-level: message framing, the argument codec, `SCM_RIGHTS` fd passing, and the raw `sendmsg`/`recvmsg` syscalls.
- `send_message_with_fds(...)` — the missing fd-passing primitive. Builds a proper `SCM_RIGHTS` control message, handles partial sends (fds attach to the first byte only), zero-fills alignment padding.
- `create_empty_memfd()` — returns an `OwnedFdRaw` wrapping a real memfd (Twilight implements `memfd_create`, syscall 319).
- `OwnedFdRaw` gains `new`/`as_raw`/`into_raw` so callers hold ownership across the send and the local copy auto-closes after the kernel duplicates it.
- `recv_raw` + `parse_chunk` replace the inlined recv path.

**2. Fixed `send_keyboard_keymap` — `src/main.rs`**

Now emits the correct 8-byte `(format, size)` payload with a real empty memfd attached via `SCM_RIGHTS`. The `OwnedFdRaw` is held across the call and dropped after, closing the local copy.

**3. Removed duplicated code from `src/main.rs`**

Deleted the redundant `Iovec`/`Msghdr`/`Cmsghdr` structs, `sendmsg`/`recvmsg` externs, `send_message`/`send_wayland_bytes`, the inlined recv body, `parse_wire_chunk`/`parse_received_fds`/`parse_header`, the entire codec, and the duplicate `WaylandHeader`/`ReceivedMessage`/`OwnedFdRaw` definitions. main.rs: ~3000 → ~2690 lines, now importing these from `wire`.

## File tree

```
userspace/apps/twland/src/
├── main.rs   (2689 lines — compositor logic)
└── wire.rs   (480 lines — wayland wire protocol + fd passing)
```

## Verification

- `cargo build --release` and `make` both succeed — statically-linked musl binary.
- `cargo clippy`: zero warnings in new code (3 remaining `collapsible_if` nits are pre-existing in untouched main.rs code).
- The `send_message_with_fds` primitive is now reusable for future fd-carrying events (e.g. a real XKB keymap memfd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected keyboard keymap event handling so empty keymap data is transmitted through the expected file-descriptor mechanism.
  * Improved handling of malformed, truncated, or invalid Wayland messages.
  * Added safer support for messages that include ancillary file descriptors.

* **Reliability**
  * Improved Wayland message encoding, decoding, and stream handling for more consistent communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->