### PR TITLE
fix(twland): send wl_output geometry/mode/done on bind

### DIFF
--- a/userspace/apps/twland/src/main.rs
+++ b/userspace/apps/twland/src/main.rs
@@ -394,8 +394,14 @@ struct SoftwareOutput {
 
 impl SoftwareOutput {
     /// The output's pixel dimensions, as `i32` for the Wayland wire format.
+    ///
+    /// Construction (`SoftwareOutput::open`) rejects dimensions that do not
+    /// fit in `i32`, so this never wraps; the `try_from` is a defensive
+    /// re-check that falls back to `i32::MAX` rather than panicking.
     fn geometry(&self) -> (i32, i32) {
-        (self.width as i32, self.height as i32)
+        let w = i32::try_from(self.width).unwrap_or(i32::MAX);
+        let h = i32::try_from(self.height).unwrap_or(i32::MAX);
+        (w, h)
     }
 }
 
@@ -883,7 +889,7 @@ fn handle_registry_bind(
     }
     if global.kind == WaylandObjectKind::Output {
         let (width, height) = output.geometry();
-        output::send_initial_events(stream, new_id, width, height)?;
+        output::send_initial_events(stream, new_id, version, width, height)?;
         println!("twland: wl_output bound, sent geometry/mode/done");
     }
 
@@ -2614,6 +2620,17 @@ impl SoftwareOutput {
                 format!(
                     "unsupported framebuffer mode {}x{} {}bpp",
                     var.xres, var.yres, var.bits_per_pixel
+                ),
+            ));
+        }
+        // Reject dimensions that do not fit in i32, so geometry() can report
+        // valid Wayland mode sizes without an unchecked cast wrapping negative.
+        if i32::try_from(var.xres).is_err() || i32::try_from(var.yres).is_err() {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "framebuffer dimensions {}x{} exceed i32 range",
+                    var.xres, var.yres
                 ),
             ));
         }

--- a/userspace/apps/twland/src/main.rs
+++ b/userspace/apps/twland/src/main.rs
@@ -7,6 +7,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::ptr;
 
+mod output;
 mod wire;
 use wire::{
     create_empty_memfd, parse_chunk, push_fixed, push_i32, push_u32, push_wayland_string,
@@ -391,6 +392,13 @@ struct SoftwareOutput {
     pixels: *mut u8,
 }
 
+impl SoftwareOutput {
+    /// The output's pixel dimensions, as `i32` for the Wayland wire format.
+    fn geometry(&self) -> (i32, i32) {
+        (self.width as i32, self.height as i32)
+    }
+}
+
 
 fn main() {
     if let Err(error) = run() {
@@ -672,7 +680,7 @@ fn dispatch_request(
         },
         WaylandObjectKind::Registry => match opcode {
             WL_REGISTRY_BIND => {
-                handle_registry_bind(client, stream, object_id, &message.payload)
+                handle_registry_bind(client, output, stream, object_id, &message.payload)
             }
             other => ignore_unimplemented("wl_registry", other, object_id),
         },
@@ -816,6 +824,7 @@ fn handle_get_registry(
 
 fn handle_registry_bind(
     client: &mut Client,
+    output: &SoftwareOutput,
     stream: &mut UnixStream,
     registry_id: u32,
     payload: &[u8],
@@ -871,6 +880,11 @@ fn handle_registry_bind(
         )?;
         send_seat_name(stream, new_id, &seat_name)?;
         println!("twland: wl_seat bound, sent pointer keyboard capabilities");
+    }
+    if global.kind == WaylandObjectKind::Output {
+        let (width, height) = output.geometry();
+        output::send_initial_events(stream, new_id, width, height)?;
+        println!("twland: wl_output bound, sent geometry/mode/done");
     }
 
     Ok(())

--- a/userspace/apps/twland/src/output.rs
+++ b/userspace/apps/twland/src/output.rs
@@ -34,7 +34,9 @@ const TRANSFORM_NORMAL: u32 = 0;
 const DEFAULT_REFRESH_MHZ: u32 = 60_000;
 
 /// Send the initial `wl_output` event sequence for a freshly bound output:
-/// `geometry`, the current `mode`, then `done`.
+/// `geometry`, the current `mode`, then `done` (only at version 2+, since
+/// `wl_output.done` was introduced in version 2 — emitting it to a v1 client
+/// is a protocol error).
 ///
 /// `width`/`height` are the output's pixel dimensions.  Physical dimensions
 /// and manufacturer/model are unknown for the framebuffer, so they are sent
@@ -42,12 +44,16 @@ const DEFAULT_REFRESH_MHZ: u32 = 60_000;
 pub fn send_initial_events(
     stream: &mut UnixStream,
     output_id: u32,
+    version: u32,
     width: i32,
     height: i32,
 ) -> io::Result<()> {
     send_geometry(stream, output_id)?;
     send_mode(stream, output_id, MODE_CURRENT | MODE_PREFERRED, width, height)?;
-    send_done(stream, output_id)
+    if version >= 2 {
+        send_done(stream, output_id)?;
+    }
+    Ok(())
 }
 
 fn send_geometry(stream: &mut UnixStream, output_id: u32) -> io::Result<()> {

--- a/userspace/apps/twland/src/output.rs
+++ b/userspace/apps/twland/src/output.rs
@@ -1,0 +1,88 @@
+//! `wl_output` event emission for twland.
+//!
+//! Owns the `wl_output` protocol details: opcodes, mode flags, and the
+//! initial event sequence sent when a client binds the output global.  A
+//! bound output must receive `geometry`, one or more `mode` events, and a
+//! final `done` (at version 2+) before the client considers the output
+//! initialized; without `done` conforming clients block waiting for it.
+//!
+//! This module knows only the output geometry (pixel width/height), not the
+//! framebuffer internals, so it stays decoupled from `SoftwareOutput`.
+
+use std::io;
+use std::os::unix::net::UnixStream;
+
+use crate::wire::{push_i32, push_u32, push_wayland_string, send_message};
+
+// wl_output events.
+const WL_OUTPUT_GEOMETRY: u16 = 0;
+const WL_OUTPUT_MODE: u16 = 1;
+const WL_OUTPUT_DONE: u16 = 2;
+
+// wl_output.mode flags.
+const MODE_CURRENT: u32 = 1;
+const MODE_PREFERRED: u32 = 2;
+
+// wl_output.subpixel: 0 = unknown.
+const SUBPIXEL_UNKNOWN: u32 = 0;
+// wl_output.transform: 0 = normal (no transform).
+const TRANSFORM_NORMAL: u32 = 0;
+
+/// A 60 Hz refresh, in millihertz, the unit `wl_output.mode` expects.  The
+/// framebuffer has no real refresh rate; this is a sane default so clients
+/// pick a reasonable frame timing.
+const DEFAULT_REFRESH_MHZ: u32 = 60_000;
+
+/// Send the initial `wl_output` event sequence for a freshly bound output:
+/// `geometry`, the current `mode`, then `done`.
+///
+/// `width`/`height` are the output's pixel dimensions.  Physical dimensions
+/// and manufacturer/model are unknown for the framebuffer, so they are sent
+/// as zero/empty — clients treat that as "unspecified".
+pub fn send_initial_events(
+    stream: &mut UnixStream,
+    output_id: u32,
+    width: i32,
+    height: i32,
+) -> io::Result<()> {
+    send_geometry(stream, output_id)?;
+    send_mode(stream, output_id, MODE_CURRENT | MODE_PREFERRED, width, height)?;
+    send_done(stream, output_id)
+}
+
+fn send_geometry(stream: &mut UnixStream, output_id: u32) -> io::Result<()> {
+    // geometry(x, y, physical_width, physical_height, subpixel, make, model, transform).
+    // Physical dimensions and make/model are unknown for the framebuffer, so
+    // they are sent as zero/empty; clients treat that as "unspecified".  The
+    // pixel width/height belong in the mode event, not here.
+    let mut payload = Vec::new();
+    push_i32(&mut payload, 0); // logical x origin
+    push_i32(&mut payload, 0); // logical y origin
+    push_i32(&mut payload, 0); // physical width (mm) — unknown
+    push_i32(&mut payload, 0); // physical height (mm) — unknown
+    push_u32(&mut payload, SUBPIXEL_UNKNOWN);
+    push_wayland_string(&mut payload, ""); // make — unknown
+    push_wayland_string(&mut payload, ""); // model — unknown
+    push_u32(&mut payload, TRANSFORM_NORMAL);
+    send_message(stream, output_id, WL_OUTPUT_GEOMETRY, &payload)
+}
+
+fn send_mode(
+    stream: &mut UnixStream,
+    output_id: u32,
+    flags: u32,
+    width: i32,
+    height: i32,
+) -> io::Result<()> {
+    // mode(flags, width, height, refresh) — refresh is in mHz.
+    let mut payload = Vec::new();
+    push_u32(&mut payload, flags);
+    push_i32(&mut payload, width);
+    push_i32(&mut payload, height);
+    push_u32(&mut payload, DEFAULT_REFRESH_MHZ);
+    send_message(stream, output_id, WL_OUTPUT_MODE, &payload)
+}
+
+fn send_done(stream: &mut UnixStream, output_id: u32) -> io::Result<()> {
+    send_message(stream, output_id, WL_OUTPUT_DONE, &[])
+}


### PR DESCRIPTION
## Summary

Fixes #41 — `wl_output` was advertised in the registry and bindable, but no `geometry`/`mode`/`done` events were ever sent, so conforming clients that bound it hung waiting for `done`.

## Root cause

Two parts:
1. `handle_registry_bind` had **no access to the framebuffer geometry** — it didn't receive `&SoftwareOutput`, so it couldn't emit the output's pixel dimensions.
2. There was **no code to emit the `wl_output` event sequence** at all. The bind handler only special-cased `wl_shm` and `wl_seat`; `wl_output` was inserted as an object and returned silently.

## Change

**1. New `wl_output` module — `src/output.rs`**

Owns the output event protocol: opcodes (`geometry`/`mode`/`done`), mode flags (`current`/`preferred`), subpixel/transform defaults, and a 60 Hz default refresh (in mHz, the unit `wl_output.mode` expects). Exposes one entry point:

```rust
pub fn send_initial_events(stream, output_id, width, height) -> io::Result<()>
```

Sends `geometry` (physical dims/make/model unknown → zero/empty; pixel dims belong in `mode`, not here), the current+preferred `mode` with the framebuffer's pixel dimensions, then `done`. The module knows only pixel geometry, not framebuffer internals, so it stays decoupled from `SoftwareOutput`.

**2. Wire it into the bind handler — `src/main.rs`**

- `SoftwareOutput::geometry()` accessor returning `(i32, i32)`.
- `handle_registry_bind` now takes `&SoftwareOutput` (threaded through `dispatch_request`, which already has it).
- On `wl_output` bind, emit the initial event sequence.

## File tree

```
userspace/apps/twland/src/
├── main.rs     (compositor logic)
├── output.rs   (wl_output event protocol — new)
└── wire.rs     (wayland wire protocol + fd passing)
```

## Verification

- `cargo build --release` + `make` both succeed.
- `cargo clippy`: no new warnings (3 pre-existing `collapsible_if` nits in untouched code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display output announcements for connected clients.
  * Reports display geometry, framebuffer dimensions, preferred/current mode, and a 60 Hz refresh rate.
  * Sends completion notifications after initial display information is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->