### PR TITLE
fix(twland): present complete frames atomically

### DIFF
--- a/userspace/apps/twland/src/framebuffer.rs
+++ b/userspace/apps/twland/src/framebuffer.rs
@@ -1,0 +1,389 @@
+//! Software framebuffer rendering and presentation.
+//!
+//! Twilight's `/dev/fb0` mapping is the kernel-owned shadow buffer, not the
+//! scan-out buffer. Drawing a frame therefore happens entirely off-screen;
+//! `FBIOPAN_DISPLAY` copies the completed shadow buffer to video memory.
+//!
+//! [`Frame`] makes that boundary explicit: callers begin a frame, perform all
+//! drawing through it, and present exactly once after composition is complete.
+
+use core::ffi::c_void;
+use std::fs::{File, OpenOptions};
+use std::io::{self, ErrorKind};
+use std::os::fd::AsRawFd;
+use std::ptr::{self, NonNull};
+
+const FB_PATH: &str = "/dev/fb0";
+const FBIOGET_VSCREENINFO: u64 = 0x4600;
+const FBIOGET_FSCREENINFO: u64 = 0x4602;
+const FBIOPAN_DISPLAY: u64 = 0x4606;
+
+const PROT_READ: i32 = 0x1;
+const PROT_WRITE: i32 = 0x2;
+const MAP_SHARED: i32 = 0x01;
+const MAP_FAILED: *mut c_void = usize::MAX as *mut c_void;
+const BYTES_PER_PIXEL: usize = 4;
+
+#[repr(C)]
+#[derive(Default)]
+struct FbVarScreenInfo {
+    xres: u32,
+    yres: u32,
+    bits_per_pixel: u32,
+    red_offset: u32,
+    green_offset: u32,
+    blue_offset: u32,
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct FbFixScreenInfo {
+    line_length: u32,
+    smem_len: u32,
+}
+
+unsafe extern "C" {
+    fn mmap(
+        addr: *mut c_void,
+        len: usize,
+        prot: i32,
+        flags: i32,
+        fd: i32,
+        offset: isize,
+    ) -> *mut c_void;
+    fn munmap(addr: *mut c_void, len: usize) -> i32;
+    fn ioctl(fd: i32, request: u64, ...) -> i32;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl Rect {
+    pub fn union(self, other: Rect) -> Rect {
+        let x0 = self.x.min(other.x);
+        let y0 = self.y.min(other.y);
+        let x1 = self
+            .x
+            .saturating_add(self.width)
+            .max(other.x.saturating_add(other.width));
+        let y1 = self
+            .y
+            .saturating_add(self.height)
+            .max(other.y.saturating_add(other.height));
+        Rect {
+            x: x0,
+            y: y0,
+            width: x1.saturating_sub(x0),
+            height: y1.saturating_sub(y0),
+        }
+    }
+}
+
+/// The mapped Twilight framebuffer shadow buffer.
+pub struct Framebuffer {
+    file: File,
+    width: usize,
+    height: usize,
+    stride: usize,
+    map_bytes: usize,
+    pixels: NonNull<u8>,
+}
+
+/// An in-progress frame that has not yet been presented.
+#[must_use = "a composed frame must be presented"]
+pub struct Frame<'a> {
+    output: &'a mut Framebuffer,
+}
+
+impl Framebuffer {
+    pub fn open() -> io::Result<Self> {
+        let file = OpenOptions::new().read(true).write(true).open(FB_PATH)?;
+        let fd = file.as_raw_fd();
+        let mut var = FbVarScreenInfo::default();
+        let mut fix = FbFixScreenInfo::default();
+
+        // SAFETY: ioctl writes to a correctly laid-out framebuffer info struct
+        // for the lifetime of this call, and `fd` is a live `/dev/fb0` handle.
+        if unsafe { ioctl(fd, FBIOGET_VSCREENINFO, &mut var) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: Same argument as above for fixed framebuffer information.
+        if unsafe { ioctl(fd, FBIOGET_FSCREENINFO, &mut fix) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if var.xres == 0 || var.yres == 0 || var.bits_per_pixel != 32 {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "unsupported framebuffer mode {}x{} {}bpp",
+                    var.xres, var.yres, var.bits_per_pixel
+                ),
+            ));
+        }
+        if i32::try_from(var.xres).is_err() || i32::try_from(var.yres).is_err() {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "framebuffer dimensions {}x{} exceed i32 range",
+                    var.xres, var.yres
+                ),
+            ));
+        }
+
+        let width = var.xres as usize;
+        let height = var.yres as usize;
+        let stride = fix.line_length as usize;
+        let map_bytes = fix.smem_len as usize;
+        let row_bytes = width
+            .checked_mul(BYTES_PER_PIXEL)
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "row size overflow"))?;
+        if stride < row_bytes || !stride.is_multiple_of(BYTES_PER_PIXEL) {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                "framebuffer stride is invalid for 32-bit pixels",
+            ));
+        }
+        let expected = height
+            .checked_mul(stride)
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "framebuffer size overflow"))?;
+        if map_bytes < expected {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                "framebuffer mapping is smaller than its geometry",
+            ));
+        }
+
+        // SAFETY: The framebuffer driver accepts a shared writable mapping of
+        // `map_bytes`. The result is checked before being wrapped in NonNull
+        // and remains owned by this object until Drop calls munmap exactly once.
+        let mapped = unsafe {
+            mmap(
+                ptr::null_mut(),
+                map_bytes,
+                PROT_READ | PROT_WRITE,
+                MAP_SHARED,
+                fd,
+                0,
+            )
+        };
+        if mapped == MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+        let Some(pixels) = NonNull::new(mapped.cast::<u8>()) else {
+            // SAFETY: `mapped` is a successful mapping that cannot be owned by
+            // NonNull, so release it before returning the validation error.
+            let _ = unsafe { munmap(mapped, map_bytes) };
+            return Err(io::Error::new(
+                ErrorKind::OutOfMemory,
+                "framebuffer mmap returned null",
+            ));
+        };
+
+        println!(
+            "twland: framebuffer {}x{} stride={} bytes",
+            width, height, stride
+        );
+
+        Ok(Self {
+            file,
+            width,
+            height,
+            stride,
+            map_bytes,
+            pixels,
+        })
+    }
+
+    /// The output's dimensions in the integer format used by Wayland.
+    pub fn geometry(&self) -> (i32, i32) {
+        // `open` rejects dimensions outside the i32 range.
+        (self.width as i32, self.height as i32)
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    /// Start composing a new off-screen frame and initialize its background.
+    pub fn begin_frame(&mut self, background: u32) -> io::Result<Frame<'_>> {
+        let mut frame = Frame { output: self };
+        frame.clear(background)?;
+        Ok(frame)
+    }
+
+    /// Replace the displayed image with a solid color as one complete frame.
+    pub fn clear_and_present(&mut self, color: u32) -> io::Result<()> {
+        self.begin_frame(color)?.present()
+    }
+
+    fn present(&mut self) -> io::Result<()> {
+        // Twilight's FBIOPAN_DISPLAY copies the completed mapped shadow buffer
+        // to video memory. It is the only operation in this module that makes
+        // an in-progress frame visible.
+        // SAFETY: `file` is a live framebuffer fd. Twilight ignores the third
+        // argument for FBIOPAN_DISPLAY, so a null pointer is the correct value.
+        let result = unsafe {
+            ioctl(
+                self.file.as_raw_fd(),
+                FBIOPAN_DISPLAY,
+                ptr::null::<c_void>(),
+            )
+        };
+        if result < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Frame<'_> {
+    pub fn width(&self) -> usize {
+        self.output.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.output.height
+    }
+
+    pub fn stride(&self) -> usize {
+        self.output.stride
+    }
+
+    fn clear(&mut self, color: u32) -> io::Result<()> {
+        for y in 0..self.output.height {
+            let row_offset = y
+                .checked_mul(self.output.stride)
+                .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "row offset overflow"))?;
+            self.fill_pixels(row_offset, self.output.width, color)?;
+        }
+        Ok(())
+    }
+
+    pub fn fill_rect(&mut self, rect: Rect, color: u32) -> io::Result<()> {
+        let x0 = rect.x.max(0) as usize;
+        let y0 = rect.y.max(0) as usize;
+        let x1 = rect
+            .x
+            .saturating_add(rect.width)
+            .clamp(0, self.output.width as i32) as usize;
+        let y1 = rect
+            .y
+            .saturating_add(rect.height)
+            .clamp(0, self.output.height as i32) as usize;
+        if x1 <= x0 || y1 <= y0 {
+            return Ok(());
+        }
+
+        for y in y0..y1 {
+            let offset = y
+                .checked_mul(self.output.stride)
+                .and_then(|row| row.checked_add(x0 * BYTES_PER_PIXEL))
+                .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "fill offset overflow"))?;
+            self.fill_pixels(offset, x1 - x0, color)?;
+        }
+        Ok(())
+    }
+
+    /// Copy one already-clipped byte span into the off-screen frame.
+    pub fn copy_bytes(&mut self, offset: usize, source: &[u8]) -> io::Result<()> {
+        let end = offset
+            .checked_add(source.len())
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "copy offset overflow"))?;
+        if end > self.output.map_bytes {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                "framebuffer copy out of bounds",
+            ));
+        }
+
+        // SAFETY: The checked destination range is within the live mmap. `copy`
+        // permits overlap, so this remains correct even if a client supplies a
+        // shared-memory pool backed by an alias of the framebuffer mapping.
+        unsafe {
+            ptr::copy(
+                source.as_ptr(),
+                self.output.pixels.as_ptr().add(offset),
+                source.len(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Publish this completed frame. Consuming `self` prevents further drawing
+    /// through the same frame after it has become visible.
+    pub fn present(self) -> io::Result<()> {
+        self.output.present()
+    }
+
+    fn fill_pixels(&mut self, byte_offset: usize, count: usize, color: u32) -> io::Result<()> {
+        let byte_len = count
+            .checked_mul(BYTES_PER_PIXEL)
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "fill size overflow"))?;
+        let end = byte_offset
+            .checked_add(byte_len)
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "fill offset overflow"))?;
+        if end > self.output.map_bytes {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                "framebuffer fill out of bounds",
+            ));
+        }
+
+        // SAFETY: The bounds checks prove the range lies within the mmap.
+        // `byte_offset` is formed from a byte stride plus a 4-byte pixel offset,
+        // so the pointer is aligned for u32 and the initialized slice is valid.
+        let pixels = unsafe {
+            std::slice::from_raw_parts_mut(
+                self.output.pixels.as_ptr().add(byte_offset).cast::<u32>(),
+                count,
+            )
+        };
+        pixels.fill(color);
+        Ok(())
+    }
+}
+
+impl Drop for Framebuffer {
+    fn drop(&mut self) {
+        // SAFETY: `pixels` and `map_bytes` describe the one successful mmap
+        // owned by this object, and Drop runs once after all Frame borrows end.
+        let _ = unsafe { munmap(self.pixels.as_ptr().cast(), self.map_bytes) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Rect;
+
+    #[test]
+    fn rect_union_covers_both_inputs() {
+        let combined = Rect {
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        }
+        .union(Rect {
+            x: 5,
+            y: 35,
+            width: 50,
+            height: 10,
+        });
+
+        assert_eq!(combined.x, 5);
+        assert_eq!(combined.y, 20);
+        assert_eq!(combined.width, 50);
+        assert_eq!(combined.height, 40);
+    }
+}

--- a/userspace/apps/twland/src/framebuffer.rs
+++ b/userspace/apps/twland/src/framebuffer.rs
@@ -23,6 +23,9 @@ const PROT_WRITE: i32 = 0x2;
 const MAP_SHARED: i32 = 0x01;
 const MAP_FAILED: *mut c_void = usize::MAX as *mut c_void;
 const BYTES_PER_PIXEL: usize = 4;
+const RED_OFFSET: u32 = 16;
+const GREEN_OFFSET: u32 = 8;
+const BLUE_OFFSET: u32 = 0;
 
 #[repr(C)]
 #[derive(Default)]
@@ -84,6 +87,59 @@ impl Rect {
     }
 }
 
+fn validate_geometry(
+    width: usize,
+    height: usize,
+    stride: usize,
+    map_bytes: usize,
+) -> io::Result<()> {
+    if width == 0 || height == 0 {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "framebuffer dimensions must be nonzero",
+        ));
+    }
+
+    let row_bytes = width
+        .checked_mul(BYTES_PER_PIXEL)
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "row size overflow"))?;
+    if stride < row_bytes || !stride.is_multiple_of(BYTES_PER_PIXEL) {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "framebuffer stride is invalid for 32-bit pixels",
+        ));
+    }
+
+    let expected = height
+        .checked_mul(stride)
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "framebuffer size overflow"))?;
+    if map_bytes < expected {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "framebuffer mapping is smaller than its geometry",
+        ));
+    }
+
+    Ok(())
+}
+
+fn clip_rect(
+    rect: Rect,
+    output_width: i32,
+    output_height: i32,
+) -> Option<(usize, usize, usize, usize)> {
+    let x0 = rect.x.clamp(0, output_width);
+    let y0 = rect.y.clamp(0, output_height);
+    let x1 = rect.x.saturating_add(rect.width).clamp(0, output_width);
+    let y1 = rect.y.saturating_add(rect.height).clamp(0, output_height);
+
+    (x1 > x0 && y1 > y0).then_some((x0 as usize, y0 as usize, x1 as usize, y1 as usize))
+}
+
+fn checked_range_end(offset: usize, len: usize, limit: usize) -> Option<usize> {
+    offset.checked_add(len).filter(|&end| end <= limit)
+}
+
 /// The mapped Twilight framebuffer shadow buffer.
 pub struct Framebuffer {
     file: File,
@@ -126,6 +182,18 @@ impl Framebuffer {
                 ),
             ));
         }
+        if var.red_offset != RED_OFFSET
+            || var.green_offset != GREEN_OFFSET
+            || var.blue_offset != BLUE_OFFSET
+        {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "unsupported framebuffer channel order r={} g={} b={}",
+                    var.red_offset, var.green_offset, var.blue_offset
+                ),
+            ));
+        }
         if i32::try_from(var.xres).is_err() || i32::try_from(var.yres).is_err() {
             return Err(io::Error::new(
                 ErrorKind::InvalidData,
@@ -140,24 +208,7 @@ impl Framebuffer {
         let height = var.yres as usize;
         let stride = fix.line_length as usize;
         let map_bytes = fix.smem_len as usize;
-        let row_bytes = width
-            .checked_mul(BYTES_PER_PIXEL)
-            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "row size overflow"))?;
-        if stride < row_bytes || !stride.is_multiple_of(BYTES_PER_PIXEL) {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                "framebuffer stride is invalid for 32-bit pixels",
-            ));
-        }
-        let expected = height
-            .checked_mul(stride)
-            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "framebuffer size overflow"))?;
-        if map_bytes < expected {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                "framebuffer mapping is smaller than its geometry",
-            ));
-        }
+        validate_geometry(width, height, stride, map_bytes)?;
 
         // SAFETY: The framebuffer driver accepts a shared writable mapping of
         // `map_bytes`. The result is checked before being wrapped in NonNull
@@ -271,19 +322,11 @@ impl Frame<'_> {
     }
 
     pub fn fill_rect(&mut self, rect: Rect, color: u32) -> io::Result<()> {
-        let x0 = rect.x.max(0) as usize;
-        let y0 = rect.y.max(0) as usize;
-        let x1 = rect
-            .x
-            .saturating_add(rect.width)
-            .clamp(0, self.output.width as i32) as usize;
-        let y1 = rect
-            .y
-            .saturating_add(rect.height)
-            .clamp(0, self.output.height as i32) as usize;
-        if x1 <= x0 || y1 <= y0 {
+        let Some((x0, y0, x1, y1)) =
+            clip_rect(rect, self.output.width as i32, self.output.height as i32)
+        else {
             return Ok(());
-        }
+        };
 
         for y in y0..y1 {
             let offset = y
@@ -295,27 +338,30 @@ impl Frame<'_> {
         Ok(())
     }
 
-    /// Copy one already-clipped byte span into the off-screen frame.
-    pub fn copy_bytes(&mut self, offset: usize, source: &[u8]) -> io::Result<()> {
-        let end = offset
-            .checked_add(source.len())
-            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "copy offset overflow"))?;
-        if end > self.output.map_bytes {
+    /// Copy one already-clipped byte span from raw memory into the off-screen frame.
+    ///
+    /// # Safety
+    ///
+    /// `source` must be readable for `len` bytes for the duration of this call.
+    /// The source may alias the framebuffer because the copy is overlap-safe.
+    pub unsafe fn copy_from_ptr(
+        &mut self,
+        offset: usize,
+        source: *const u8,
+        len: usize,
+    ) -> io::Result<()> {
+        if checked_range_end(offset, len, self.output.map_bytes).is_none() {
             return Err(io::Error::new(
                 ErrorKind::InvalidData,
                 "framebuffer copy out of bounds",
             ));
         }
 
-        // SAFETY: The checked destination range is within the live mmap. `copy`
-        // permits overlap, so this remains correct even if a client supplies a
-        // shared-memory pool backed by an alias of the framebuffer mapping.
+        // SAFETY: The caller guarantees that `source` is readable for `len`
+        // bytes. The checked destination range lies within the live mmap, and
+        // `copy` permits overlap between the source and destination ranges.
         unsafe {
-            ptr::copy(
-                source.as_ptr(),
-                self.output.pixels.as_ptr().add(offset),
-                source.len(),
-            );
+            ptr::copy(source, self.output.pixels.as_ptr().add(offset), len);
         }
         Ok(())
     }
@@ -330,10 +376,7 @@ impl Frame<'_> {
         let byte_len = count
             .checked_mul(BYTES_PER_PIXEL)
             .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "fill size overflow"))?;
-        let end = byte_offset
-            .checked_add(byte_len)
-            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "fill offset overflow"))?;
-        if end > self.output.map_bytes {
+        if checked_range_end(byte_offset, byte_len, self.output.map_bytes).is_none() {
             return Err(io::Error::new(
                 ErrorKind::InvalidData,
                 "framebuffer fill out of bounds",
@@ -364,7 +407,7 @@ impl Drop for Framebuffer {
 
 #[cfg(test)]
 mod tests {
-    use super::Rect;
+    use super::{Rect, checked_range_end, clip_rect, validate_geometry};
 
     #[test]
     fn rect_union_covers_both_inputs() {
@@ -385,5 +428,96 @@ mod tests {
         assert_eq!(combined.y, 20);
         assert_eq!(combined.width, 50);
         assert_eq!(combined.height, 40);
+    }
+
+    #[test]
+    fn clip_rect_rejects_rectangles_outside_each_edge() {
+        let outside = [
+            Rect {
+                x: -20,
+                y: 10,
+                width: 10,
+                height: 10,
+            },
+            Rect {
+                x: 100,
+                y: 10,
+                width: 10,
+                height: 10,
+            },
+            Rect {
+                x: 10,
+                y: -20,
+                width: 10,
+                height: 10,
+            },
+            Rect {
+                x: 10,
+                y: 80,
+                width: 10,
+                height: 10,
+            },
+        ];
+
+        for rect in outside {
+            assert_eq!(clip_rect(rect, 100, 80), None);
+        }
+    }
+
+    #[test]
+    fn clip_rect_handles_edges_and_extreme_inputs() {
+        assert_eq!(
+            clip_rect(
+                Rect {
+                    x: -5,
+                    y: 70,
+                    width: 20,
+                    height: 20,
+                },
+                100,
+                80,
+            ),
+            Some((0, 70, 15, 80))
+        );
+        assert_eq!(
+            clip_rect(
+                Rect {
+                    x: 10,
+                    y: 10,
+                    width: -1,
+                    height: 10,
+                },
+                100,
+                80,
+            ),
+            None
+        );
+        assert_eq!(
+            clip_rect(
+                Rect {
+                    x: i32::MAX,
+                    y: i32::MAX,
+                    width: i32::MAX,
+                    height: i32::MAX,
+                },
+                100,
+                80,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn validate_geometry_rejects_short_stride_and_mapping() {
+        assert!(validate_geometry(100, 80, 399, 32_000).is_err());
+        assert!(validate_geometry(100, 80, 400, 31_999).is_err());
+        assert!(validate_geometry(100, 80, 400, 32_000).is_ok());
+    }
+
+    #[test]
+    fn checked_range_end_rejects_overflow_and_out_of_bounds_ranges() {
+        assert_eq!(checked_range_end(4, 4, 8), Some(8));
+        assert_eq!(checked_range_end(4, 5, 8), None);
+        assert_eq!(checked_range_end(usize::MAX, 1, usize::MAX), None);
     }
 }

--- a/userspace/apps/twland/src/main.rs
+++ b/userspace/apps/twland/src/main.rs
@@ -1,15 +1,16 @@
 use core::ffi::c_void;
 use std::collections::{HashMap, VecDeque};
-use std::fs::{self, File, OpenOptions};
+use std::fs;
 use std::io::{self, ErrorKind};
-use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::ptr;
 
+mod framebuffer;
 mod input;
 mod output;
 mod wire;
+use framebuffer::{Frame, Framebuffer, Rect};
 use wire::{
     create_empty_memfd, parse_chunk, push_fixed, push_i32, push_u32, push_wayland_string,
     read_i32, read_u32, read_wayland_string, recv_raw, send_message, OwnedFdRaw,
@@ -18,8 +19,6 @@ use wire::{
 
 const RUNTIME_DIR: &str = "/run/user/0";
 const WAYLAND_SOCKET: &str = "/run/user/0/wayland-0";
-const FB_PATH: &str = "/dev/fb0";
-
 const WL_DISPLAY_SYNC: u16 = 0;
 const WL_DISPLAY_GET_REGISTRY: u16 = 1;
 const WL_CALLBACK_DONE: u16 = 0;
@@ -80,12 +79,7 @@ const BORDER_WIDTH: i32 = 2;
 const CLOSE_BUTTON_SIZE: i32 = 18;
 const DESKTOP_BACKGROUND: u32 = 0xff101018;
 
-const FBIOGET_VSCREENINFO: u64 = 0x4600;
-const FBIOGET_FSCREENINFO: u64 = 0x4602;
-const FBIOPAN_DISPLAY: u64 = 0x4606;
-
 const PROT_READ: i32 = 0x1;
-const PROT_WRITE: i32 = 0x2;
 const MAP_SHARED: i32 = 0x01;
 const MAP_FAILED: *mut c_void = usize::MAX as *mut c_void;
 
@@ -122,24 +116,6 @@ const GLOBALS: &[Global] = &[
     },
 ];
 
-#[repr(C)]
-#[derive(Default)]
-struct FbVarScreenInfo {
-    xres: u32,
-    yres: u32,
-    bits_per_pixel: u32,
-    red_offset: u32,
-    green_offset: u32,
-    blue_offset: u32,
-}
-
-#[repr(C)]
-#[derive(Default)]
-struct FbFixScreenInfo {
-    line_length: u32,
-    smem_len: u32,
-}
-
 unsafe extern "C" {
     fn sched_yield() -> i32;
     fn mmap(
@@ -152,7 +128,6 @@ unsafe extern "C" {
     ) -> *mut c_void;
     fn munmap(addr: *mut c_void, len: usize) -> i32;
     fn close(fd: i32) -> i32;
-    fn ioctl(fd: i32, request: u64, ...) -> i32;
 }
 
 struct Client {
@@ -377,43 +352,12 @@ struct XdgToplevelState {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct Rect {
-    x: i32,
-    y: i32,
-    width: i32,
-    height: i32,
-}
-
-#[derive(Debug, Clone, Copy)]
 struct Global {
     name: u32,
     interface: &'static str,
     version: u32,
     kind: WaylandObjectKind,
 }
-
-struct SoftwareOutput {
-    _file: File,
-    width: usize,
-    height: usize,
-    stride: usize,
-    map_bytes: usize,
-    pixels: *mut u8,
-}
-
-impl SoftwareOutput {
-    /// The output's pixel dimensions, as `i32` for the Wayland wire format.
-    ///
-    /// Construction (`SoftwareOutput::open`) rejects dimensions that do not
-    /// fit in `i32`, so this never wraps; the `try_from` is a defensive
-    /// re-check that falls back to `i32::MAX` rather than panicking.
-    fn geometry(&self) -> (i32, i32) {
-        let w = i32::try_from(self.width).unwrap_or(i32::MAX);
-        let h = i32::try_from(self.height).unwrap_or(i32::MAX);
-        (w, h)
-    }
-}
-
 
 fn main() {
     if let Err(error) = run() {
@@ -429,8 +373,8 @@ fn run() -> io::Result<()> {
     ensure_dir("/run/user")?;
     ensure_dir(RUNTIME_DIR)?;
 
-    let mut output = SoftwareOutput::open()?;
-    output.clear(DESKTOP_BACKGROUND)?;
+    let mut output = Framebuffer::open()?;
+    output.clear_and_present(DESKTOP_BACKGROUND)?;
     println!("twland: framebuffer cleared");
 
     match fs::remove_file(WAYLAND_SOCKET) {
@@ -451,7 +395,7 @@ fn run() -> io::Result<()> {
                 } else {
                     println!("twland: client disconnected");
                 }
-                let _ = output.clear(DESKTOP_BACKGROUND);
+                let _ = output.clear_and_present(DESKTOP_BACKGROUND);
             }
             Err(error) if error.kind() == ErrorKind::Interrupted => continue,
             Err(error) => eprintln!("twland: accept failed: {error}"),
@@ -475,7 +419,7 @@ fn ensure_dir(path: &str) -> io::Result<()> {
     }
 }
 
-fn handle_client(mut stream: UnixStream, output: &mut SoftwareOutput) -> io::Result<()> {
+fn handle_client(mut stream: UnixStream, output: &mut Framebuffer) -> io::Result<()> {
     let mut client = Client::new();
 
     loop {
@@ -686,7 +630,7 @@ impl Client {
 
 fn dispatch_request(
     client: &mut Client,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     stream: &mut UnixStream,
     message: ReceivedMessage,
 ) -> io::Result<()> {
@@ -858,7 +802,7 @@ fn handle_get_registry(
 
 fn handle_registry_bind(
     client: &mut Client,
-    output: &SoftwareOutput,
+    output: &Framebuffer,
     stream: &mut UnixStream,
     registry_id: u32,
     payload: &[u8],
@@ -1119,7 +1063,7 @@ fn handle_buffer_destroy(client: &mut Client, buffer_id: u32) {
 
 fn handle_surface_destroy(
     client: &mut Client,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     surface_id: u32,
 ) -> io::Result<()> {
     client.objects.remove(&surface_id);
@@ -1330,10 +1274,9 @@ fn handle_xdg_toplevel_set_title(
         .xdg_surfaces
         .get(&xdg_surface_id)
         .map(|xdg_surface| xdg_surface.wl_surface_id)
+        && let Some(window) = client.window_for_surface_mut(surface_id)
     {
-        if let Some(window) = client.window_for_surface_mut(surface_id) {
-            window.title = title.clone();
-        }
+        window.title = title.clone();
     }
     println!("twland: xdg_toplevel.set_title \"{}\"", title);
     Ok(())
@@ -1357,10 +1300,9 @@ fn handle_xdg_toplevel_set_app_id(
         .xdg_surfaces
         .get(&xdg_surface_id)
         .map(|xdg_surface| xdg_surface.wl_surface_id)
+        && let Some(window) = client.window_for_surface_mut(surface_id)
     {
-        if let Some(window) = client.window_for_surface_mut(surface_id) {
-            window.app_id = app_id.clone();
-        }
+        window.app_id = app_id.clone();
     }
     println!("twland: xdg_toplevel.set_app_id \"{}\"", app_id);
     Ok(())
@@ -1368,7 +1310,7 @@ fn handle_xdg_toplevel_set_app_id(
 
 fn handle_xdg_surface_destroy(
     client: &mut Client,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     xdg_surface_id: u32,
 ) -> io::Result<()> {
     client.objects.remove(&xdg_surface_id);
@@ -1392,7 +1334,7 @@ fn handle_xdg_surface_destroy(
 
 fn handle_xdg_toplevel_destroy(
     client: &mut Client,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     toplevel_id: u32,
 ) -> io::Result<()> {
     client.objects.remove(&toplevel_id);
@@ -1415,7 +1357,7 @@ fn handle_xdg_toplevel_destroy(
 
 fn handle_surface_commit(
     client: &mut Client,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     stream: &mut UnixStream,
     surface_id: u32,
 ) -> io::Result<()> {
@@ -1666,11 +1608,11 @@ fn remove_window_for_surface(client: &mut Client, surface_id: u32) {
     }
 }
 
-fn redraw_scene(client: &mut Client, output: &mut SoftwareOutput) -> io::Result<()> {
-    output.clear(DESKTOP_BACKGROUND)?;
+fn redraw_scene(client: &mut Client, output: &mut Framebuffer) -> io::Result<()> {
+    let mut frame = output.begin_frame(DESKTOP_BACKGROUND)?;
     let windows = client.compositor.windows.clone();
     for window in windows.iter().filter(|window| window.mapped) {
-        draw_window_decoration(output, window)?;
+        draw_window_decoration(&mut frame, window)?;
         let Some(surface) = client.surfaces.get(&window.surface_id).cloned() else {
             continue;
         };
@@ -1695,16 +1637,16 @@ fn redraw_scene(client: &mut Client, output: &mut SoftwareOutput) -> io::Result<
             width: buffer.width,
             height: buffer.height,
         };
-        let _ = blit_shm_buffer_to_output(output, pool, &buffer, &draw_surface, damage)?;
+        let _ = blit_shm_buffer_to_output(&mut frame, pool, &buffer, &draw_surface, damage)?;
     }
-    draw_cursor(output, client.input.pointer_x, client.input.pointer_y)?;
-    output.sync()
+    draw_cursor(&mut frame, client.input.pointer_x, client.input.pointer_y)?;
+    frame.present()
 }
 
 /// Draw an X-shaped cursor at the pointer position.  The compositor owns the
 /// cursor (Wayland server-side cursor), so this is drawn on top of all windows
 /// after the scene is composited.
-fn draw_cursor(output: &mut SoftwareOutput, x: i32, y: i32) -> io::Result<()> {
+fn draw_cursor(output: &mut Frame<'_>, x: i32, y: i32) -> io::Result<()> {
     let outline = 0xff000000u32;
     let fill = 0xffffffffu32;
 
@@ -1736,7 +1678,7 @@ fn draw_cursor(output: &mut SoftwareOutput, x: i32, y: i32) -> io::Result<()> {
     Ok(())
 }
 
-fn draw_window_decoration(output: &mut SoftwareOutput, window: &Window) -> io::Result<()> {
+fn draw_window_decoration(output: &mut Frame<'_>, window: &Window) -> io::Result<()> {
     if !window.decoration.enabled {
         return Ok(());
     }
@@ -1782,7 +1724,7 @@ fn draw_window_decoration(output: &mut SoftwareOutput, window: &Window) -> io::R
     Ok(())
 }
 
-fn draw_close_glyph(output: &mut SoftwareOutput, rect: Rect) -> io::Result<()> {
+fn draw_close_glyph(output: &mut Frame<'_>, rect: Rect) -> io::Result<()> {
     for i in 4..(rect.width - 4).max(4) {
         output.fill_rect(
             Rect {
@@ -1863,7 +1805,7 @@ fn rect_contains(rect: Rect, x: i32, y: i32) -> bool {
 fn focus_window(
     client: &mut Client,
     stream: &mut UnixStream,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     surface_id: u32,
     send_configure: bool,
 ) -> io::Result<()> {
@@ -1961,7 +1903,7 @@ fn poll_input_events(client: &mut Client) -> Vec<TwlandInputEvent> {
 fn dispatch_input_event(
     client: &mut Client,
     stream: &mut UnixStream,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     event: TwlandInputEvent,
 ) -> io::Result<()> {
     match event {
@@ -1985,12 +1927,12 @@ fn dispatch_input_event(
 fn dispatch_pointer_position(
     client: &mut Client,
     stream: &mut UnixStream,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     x: i32,
     y: i32,
 ) -> io::Result<()> {
-    let max_x = output.width.saturating_sub(1) as i32;
-    let max_y = output.height.saturating_sub(1) as i32;
+    let max_x = output.width().saturating_sub(1) as i32;
+    let max_y = output.height().saturating_sub(1) as i32;
     client.input.pointer_x = x.clamp(0, max_x);
     client.input.pointer_y = y.clamp(0, max_y);
 
@@ -2056,7 +1998,7 @@ fn dispatch_pointer_position(
 fn dispatch_pointer_button(
     client: &mut Client,
     stream: &mut UnixStream,
-    output: &mut SoftwareOutput,
+    output: &mut Framebuffer,
     button: u32,
     pressed: bool,
 ) -> io::Result<()> {
@@ -2066,12 +2008,10 @@ fn dispatch_pointer_button(
         client.input.buttons &= !1;
     }
 
-    if !pressed {
-        if let Some(drag) = client.compositor.drag.take() {
-            println!("twland: end drag surface={}", drag.surface_id);
-            redraw_scene(client, output)?;
-            return Ok(());
-        }
+    if !pressed && let Some(drag) = client.compositor.drag.take() {
+        println!("twland: end drag surface={}", drag.surface_id);
+        redraw_scene(client, output)?;
+        return Ok(());
     }
 
     let hit = hit_test(
@@ -2464,7 +2404,7 @@ fn send_keyboard_key(
 }
 
 fn blit_shm_buffer_to_output(
-    output: &mut SoftwareOutput,
+    output: &mut Frame<'_>,
     pool: &ShmPoolState,
     buffer: &BufferState,
     surface: &SurfaceState,
@@ -2497,7 +2437,7 @@ fn blit_shm_buffer_to_output(
         src_y0 -= dst_y0;
         dst_y0 = 0;
     }
-    if dst_x0 >= output.width as i32 || dst_y0 >= output.height as i32 {
+    if dst_x0 >= output.width() as i32 || dst_y0 >= output.height() as i32 {
         return Ok(Rect {
             x: 0,
             y: 0,
@@ -2506,8 +2446,8 @@ fn blit_shm_buffer_to_output(
         });
     }
 
-    let max_width = (output.width as i32 - dst_x0).max(0);
-    let max_height = (output.height as i32 - dst_y0).max(0);
+    let max_width = (output.width() as i32 - dst_x0).max(0);
+    let max_height = (output.height() as i32 - dst_y0).max(0);
     src_x1 = src_x1.min(src_x0 + max_width);
     src_y1 = src_y1.min(src_y0 + max_height);
     let width = src_x1 - src_x0;
@@ -2528,32 +2468,43 @@ fn blit_shm_buffer_to_output(
     let width = width as usize;
     let height = height as usize;
     let stride = buffer.stride as usize;
+    let row_bytes = width
+        .checked_mul(4)
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "source row size overflow"))?;
+
+    if pool.mapped_addr.is_null() || pool.size == 0 {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "shared-memory pool is not mapped",
+        ));
+    }
+    // SAFETY: A live ShmPoolState owns this read-only mmap for `pool.size`
+    // bytes. The pool cannot be destroyed while it is immutably borrowed here.
+    let pool_bytes = unsafe { std::slice::from_raw_parts(pool.mapped_addr, pool.size) };
 
     for row in 0..height {
+        let src_row = src_y0
+            .checked_add(row)
+            .and_then(|y| y.checked_mul(stride))
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "source row overflow"))?;
         let src_offset = buffer
             .offset
-            .checked_add((src_y0 + row) * stride)
+            .checked_add(src_row)
             .and_then(|offset| offset.checked_add(src_x0 * 4))
             .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "source offset overflow"))?;
-        let dst_offset = (dst_y0 + row)
-            .checked_mul(output.stride)
-            .and_then(|offset| offset.checked_add(dst_x0 * 4))
-            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "destination offset overflow"))?;
-        let row_bytes = width * 4;
-        if src_offset + row_bytes > pool.size || dst_offset + row_bytes > output.map_bytes {
-            return Err(io::Error::new(ErrorKind::InvalidData, "blit out of bounds"));
+        let src_end = src_offset
+            .checked_add(row_bytes)
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "source end overflow"))?;
+        if src_end > pool_bytes.len() {
+            return Err(io::Error::new(ErrorKind::InvalidData, "blit source out of bounds"));
         }
 
-        // SAFETY: Bounds checks above prove both source and destination row
-        // ranges are within their mmap regions. The framebuffer and memfd
-        // mappings are distinct, non-overlapping mappings.
-        unsafe {
-            ptr::copy_nonoverlapping(
-                pool.mapped_addr.add(src_offset),
-                output.pixels.add(dst_offset),
-                row_bytes,
-            );
-        }
+        let dst_offset = dst_y0
+            .checked_add(row)
+            .and_then(|y| y.checked_mul(output.stride()))
+            .and_then(|offset| offset.checked_add(dst_x0 * 4))
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "destination offset overflow"))?;
+        output.copy_bytes(dst_offset, &pool_bytes[src_offset..src_end])?;
     }
 
     println!("twland: blit {}x{} at {},{}", width, height, dst_x0, dst_y0);
@@ -2577,167 +2528,6 @@ fn unsafe_mmap_shm(fd: i32, size: usize) -> io::Result<*mut u8> {
     }
 }
 
-impl SoftwareOutput {
-    fn open() -> io::Result<Self> {
-        let file = OpenOptions::new().read(true).write(true).open(FB_PATH)?;
-        let fd = file.as_raw_fd();
-        let mut var = FbVarScreenInfo::default();
-        let mut fix = FbFixScreenInfo::default();
-
-        // SAFETY: ioctl writes into valid framebuffer info structs for a live
-        // /dev/fb0 fd. Constants match Twilight's framebuffer device ABI.
-        let var_result = unsafe { ioctl(fd, FBIOGET_VSCREENINFO, &mut var) };
-        if var_result < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        // SAFETY: Same as above for fixed screen information.
-        let fix_result = unsafe { ioctl(fd, FBIOGET_FSCREENINFO, &mut fix) };
-        if fix_result < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        if var.xres == 0 || var.yres == 0 || var.bits_per_pixel != 32 {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                format!(
-                    "unsupported framebuffer mode {}x{} {}bpp",
-                    var.xres, var.yres, var.bits_per_pixel
-                ),
-            ));
-        }
-        // Reject dimensions that do not fit in i32, so geometry() can report
-        // valid Wayland mode sizes without an unchecked cast wrapping negative.
-        if i32::try_from(var.xres).is_err() || i32::try_from(var.yres).is_err() {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                format!(
-                    "framebuffer dimensions {}x{} exceed i32 range",
-                    var.xres, var.yres
-                ),
-            ));
-        }
-
-        let map_bytes = fix.smem_len as usize;
-        let expected = (var.yres as usize)
-            .checked_mul(fix.line_length as usize)
-            .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "framebuffer size overflow"))?;
-        if map_bytes < expected {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                "framebuffer mapping is smaller than geometry",
-            ));
-        }
-
-        // SAFETY: The framebuffer fd supports MAP_SHARED mmap. Pointer is
-        // checked against MAP_FAILED and owned by SoftwareOutput until Drop.
-        let pixels = unsafe {
-            mmap(
-                ptr::null_mut(),
-                map_bytes,
-                PROT_READ | PROT_WRITE,
-                MAP_SHARED,
-                fd,
-                0,
-            )
-        };
-        if pixels == MAP_FAILED {
-            return Err(io::Error::last_os_error());
-        }
-
-        println!(
-            "twland: framebuffer {}x{} stride={} bytes",
-            var.xres, var.yres, fix.line_length
-        );
-
-        Ok(Self {
-            _file: file,
-            width: var.xres as usize,
-            height: var.yres as usize,
-            stride: fix.line_length as usize,
-            map_bytes,
-            pixels: pixels.cast(),
-        })
-    }
-
-    fn clear(&mut self, color: u32) -> io::Result<()> {
-        for y in 0..self.height {
-            let row_offset = y
-                .checked_mul(self.stride)
-                .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "row offset overflow"))?;
-            // SAFETY: row_offset is inside the framebuffer mapping and each row
-            // writes exactly `width * 4` bytes, which is <= stride by fb init.
-            let row = unsafe {
-                std::slice::from_raw_parts_mut(
-                    self.pixels.add(row_offset).cast::<u32>(),
-                    self.width,
-                )
-            };
-            row.fill(color);
-        }
-        self.sync()
-    }
-
-    fn fill_rect(&mut self, rect: Rect, color: u32) -> io::Result<()> {
-        let x0 = rect.x.max(0) as usize;
-        let y0 = rect.y.max(0) as usize;
-        let x1 = rect
-            .x
-            .saturating_add(rect.width)
-            .clamp(0, self.width as i32) as usize;
-        let y1 = rect
-            .y
-            .saturating_add(rect.height)
-            .clamp(0, self.height as i32) as usize;
-        if x1 <= x0 || y1 <= y0 {
-            return Ok(());
-        }
-
-        for y in y0..y1 {
-            let offset = y
-                .checked_mul(self.stride)
-                .and_then(|row| row.checked_add(x0 * 4))
-                .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "fill offset overflow"))?;
-            let len = x1 - x0;
-            if offset + len * 4 > self.map_bytes {
-                return Err(io::Error::new(ErrorKind::InvalidData, "fill out of bounds"));
-            }
-            // SAFETY: The row slice is fully bounds-checked against the mmap
-            // size above and is within the framebuffer's 32-bit pixel format.
-            let row = unsafe {
-                std::slice::from_raw_parts_mut(self.pixels.add(offset).cast::<u32>(), len)
-            };
-            row.fill(color);
-        }
-        Ok(())
-    }
-
-    fn sync(&mut self) -> io::Result<()> {
-        // SAFETY: ioctl is called on the live framebuffer fd and does not read
-        // the null third argument for FBIOPAN_DISPLAY in Twilight.
-        let result = unsafe {
-            ioctl(
-                self._file.as_raw_fd(),
-                FBIOPAN_DISPLAY,
-                ptr::null::<c_void>(),
-            )
-        };
-        if result < 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(())
-        }
-    }
-}
-
-impl Drop for SoftwareOutput {
-    fn drop(&mut self) {
-        if !self.pixels.is_null() && self.map_bytes != 0 {
-            // SAFETY: `pixels` and `map_bytes` come from a successful mmap in
-            // SoftwareOutput::open and are unmapped exactly once here.
-            let _ = unsafe { munmap(self.pixels.cast(), self.map_bytes) };
-        }
-    }
-}
-
 impl Drop for ShmPoolState {
     fn drop(&mut self) {
         if !self.mapped_addr.is_null() && self.size != 0 {
@@ -2749,28 +2539,6 @@ impl Drop for ShmPoolState {
             // SAFETY: fd is owned by this pool after OwnedFdRaw::into_raw.
             let _ = unsafe { close(self.fd) };
             self.fd = -1;
-        }
-    }
-}
-
-
-impl Rect {
-    fn union(self, other: Rect) -> Rect {
-        let x0 = self.x.min(other.x);
-        let y0 = self.y.min(other.y);
-        let x1 = self
-            .x
-            .saturating_add(self.width)
-            .max(other.x.saturating_add(other.width));
-        let y1 = self
-            .y
-            .saturating_add(self.height)
-            .max(other.y.saturating_add(other.height));
-        Rect {
-            x: x0,
-            y: y0,
-            width: x1.saturating_sub(x0),
-            height: y1.saturating_sub(y0),
         }
     }
 }

--- a/userspace/apps/twland/src/main.rs
+++ b/userspace/apps/twland/src/main.rs
@@ -1637,7 +1637,7 @@ fn redraw_scene(client: &mut Client, output: &mut Framebuffer) -> io::Result<()>
             width: buffer.width,
             height: buffer.height,
         };
-        let _ = blit_shm_buffer_to_output(&mut frame, pool, &buffer, &draw_surface, damage)?;
+        blit_shm_buffer_to_output(&mut frame, pool, &buffer, &draw_surface, damage)?;
     }
     draw_cursor(&mut frame, client.input.pointer_x, client.input.pointer_y)?;
     frame.present()
@@ -2478,10 +2478,6 @@ fn blit_shm_buffer_to_output(
             "shared-memory pool is not mapped",
         ));
     }
-    // SAFETY: A live ShmPoolState owns this read-only mmap for `pool.size`
-    // bytes. The pool cannot be destroyed while it is immutably borrowed here.
-    let pool_bytes = unsafe { std::slice::from_raw_parts(pool.mapped_addr, pool.size) };
-
     for row in 0..height {
         let src_row = src_y0
             .checked_add(row)
@@ -2495,8 +2491,11 @@ fn blit_shm_buffer_to_output(
         let src_end = src_offset
             .checked_add(row_bytes)
             .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "source end overflow"))?;
-        if src_end > pool_bytes.len() {
-            return Err(io::Error::new(ErrorKind::InvalidData, "blit source out of bounds"));
+        if src_end > pool.size {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                "blit source out of bounds",
+            ));
         }
 
         let dst_offset = dst_y0
@@ -2504,7 +2503,14 @@ fn blit_shm_buffer_to_output(
             .and_then(|y| y.checked_mul(output.stride()))
             .and_then(|offset| offset.checked_add(dst_x0 * 4))
             .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "destination offset overflow"))?;
-        output.copy_bytes(dst_offset, &pool_bytes[src_offset..src_end])?;
+        // SAFETY: ShmPoolState owns a shared, readable mapping of `pool.size`
+        // bytes and cannot be destroyed during this borrow. The bounds check
+        // above proves this row is readable. Keeping the source as a raw
+        // pointer avoids claiming that client-writable shared memory is an
+        // immutable Rust slice.
+        unsafe {
+            output.copy_from_ptr(dst_offset, pool.mapped_addr.add(src_offset), row_bytes)?;
+        }
     }
 
     println!("twland: blit {}x{} at {},{}", width, height, dst_x0, dst_y0);

--- a/userspace/apps/twland/src/output.rs
+++ b/userspace/apps/twland/src/output.rs
@@ -7,7 +7,7 @@
 //! initialized; without `done` conforming clients block waiting for it.
 //!
 //! This module knows only the output geometry (pixel width/height), not the
-//! framebuffer internals, so it stays decoupled from `SoftwareOutput`.
+//! framebuffer internals, so it stays decoupled from the rendering module.
 
 use std::io;
 use std::os::unix::net::UnixStream;


### PR DESCRIPTION
## Summary

- introduce an explicit frame composition and presentation boundary
- render the background, windows, client buffers, and cursor into the framebuffer shadow mapping before presenting
- isolate framebuffer ownership, validation, cleanup, and unsafe operations in a dedicated module
- harden shared-memory blits with checked offsets and bounds

## Root cause

The `/dev/fb0` mapping is already a kernel-side shadow buffer. `SoftwareOutput::clear()` called `FBIOPAN_DISPLAY` immediately, exposing the cleared frame before the scene was redrawn. Dragging generated enough redraws to make that incomplete intermediate frame visible as flicker.

A `Frame` now represents an in-progress composition and can only be presented after all drawing is complete, leaving one presentation point per scene redraw.

## Validation

- `cargo test --manifest-path userspace/apps/twland/Cargo.toml --target x86_64-unknown-linux-musl`
- `cargo clippy --manifest-path userspace/apps/twland/Cargo.toml --target x86_64-unknown-linux-musl -- -D warnings`
- `make -C userspace/apps/twland`
- `make -C . twilight-os.iso`
- booted the generated ISO in QEMU and verified live window dragging produces a complete frame
- `git diff --check`

Fixes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added software framebuffer rendering with support for clearing, drawing clipped rectangles, copying pixel data, and presenting completed frames.
  * Added framebuffer geometry and dimension accessors for rendering workflows.

* **Bug Fixes**
  * Added validation for framebuffer geometry, memory mapping, drawing bounds, shared-memory ranges, and buffer offsets.
  * Improved cleanup when framebuffer resources are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->