### PR TITLE
fix(time): replace interrupt-count clocksource with invariant-TSC clocksource

### DIFF
--- a/kernel/twilight_kernel/src/driver/apic/lapic.rs
+++ b/kernel/twilight_kernel/src/driver/apic/lapic.rs
@@ -67,19 +67,19 @@ pub fn init() {
 }
 
 fn calibrate_timer() {
-    // 1. Setup PIT for 10ms wait
-    // We'll trust our existing pit::sleep_ns or just busy wait on it.
-    // However, we need to handle the case where we might be running inside an interrupt context or similar logic?
-    // Actually, init() is called early in main(), interrupts enabled?
-    // We should assume interrupts are potentially enabled, or we can just spin poll the PIT.
+    // Calibrate the LAPIC timer interval against the TSC clocksource, not the
+    // interrupt-count clock. The old code called `pit::sleep_ns(10ms)`, which
+    // counted delivered timer interrupts; under KVM those can be coalesced,
+    // producing an interval that is too long and a clock that runs slow for the
+    // whole boot (#62). Busy-waiting on the TSC measures real elapsed time.
 
     unsafe {
         // One shot mode, large value
         write_reg(TICR_REG, 0xFFFFFFFF);
     }
 
-    // Wait 10ms
-    crate::driver::timer::pit::sleep_ns(10_000_000);
+    // Wait 10 ms of real time using the TSC.
+    crate::driver::timer::wait(10_000_000);
 
     let ticks_in_10ms = unsafe {
         let current = read_reg(TCCR_REG);

--- a/kernel/twilight_kernel/src/driver/cpu/mod.rs
+++ b/kernel/twilight_kernel/src/driver/cpu/mod.rs
@@ -27,7 +27,7 @@ pub fn init_smp(mp_response: &'static MpResponse) {
     let bsp_id = mp_response.bsp_lapic_id();
     CPU_COUNT.store(smp.cpus().len(), Ordering::Relaxed);
 
-    let time = driver::timer::pit::uptime();
+    let time = driver::time::uptime_secs_f64();
 
     for i in 0..smp.cpus().len() {
         let cpu = smp.cpus().get(i).unwrap();
@@ -54,7 +54,7 @@ pub const IA32_KERNEL_GS_BASE: u32 = 0xc0000102;
 
 pub fn init(mp_response: &'static MpResponse) {
     let cpuid = CpuId::new();
-    let time = driver::timer::pit::uptime();
+    let time = driver::time::uptime_secs_f64();
 
     let name = if let Some(cpu) = cpuid.get_processor_brand_string() {
         String::from(cpu.as_str())

--- a/kernel/twilight_kernel/src/driver/disk/ata.rs
+++ b/kernel/twilight_kernel/src/driver/disk/ata.rs
@@ -152,9 +152,9 @@ impl Bus {
     }
 
     fn poll(&mut self, bit: Status, val: bool) -> Result<(), ()> {
-        let start = crate::driver::timer::pit::uptime();
+        let start = crate::driver::time::uptime_secs_f64();
         while self.status().get_bit(bit as usize) != val {
-            if crate::driver::timer::pit::uptime() - start > 1.0 {
+            if crate::driver::time::uptime_secs_f64() - start > 1.0 {
                 println!("ATA hanged while polling {:?} bit in status register", bit);
                 self.debug();
                 return Err(());
@@ -406,7 +406,7 @@ fn ensure_buses() {
 pub fn init() {
     ensure_buses();
 
-    let time = crate::driver::timer::pit::uptime();
+    let time = crate::driver::time::uptime_secs_f64();
     let drives = list();
 
     for drive in drives {

--- a/kernel/twilight_kernel/src/driver/disk/ata_dma.rs
+++ b/kernel/twilight_kernel/src/driver/disk/ata_dma.rs
@@ -1236,7 +1236,7 @@ lazy_static! {
 fn maybe_log_perf() {
     #[cfg(debug_assertions)]
     {
-        let now = crate::driver::timer::pit::uptime();
+        let now = crate::driver::time::uptime_secs_f64();
         let mut st = PERF_LOG_STATE.lock();
         if st.last_ts == 0.0 {
             st.last_ts = now;
@@ -1454,7 +1454,7 @@ pub fn init() {
         ));
     }
 
-    let time = crate::driver::timer::pit::uptime();
+    let time = crate::driver::time::uptime_secs_f64();
     println!(
         "\x1b[93m[{:.6}]\x1b[0m ATA-DMA mode queue={} dma_buf={}KiB",
         time,

--- a/kernel/twilight_kernel/src/driver/keyboard/mod.rs
+++ b/kernel/twilight_kernel/src/driver/keyboard/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use crate::arch::x86_64::halt;
-use crate::driver::timer::pit::uptime;
+use crate::driver::time::uptime_secs_f64 as uptime;
 use crate::sys::console::put_char_in_tty;
 use crate::sys::fs::vfs::{BlockDev, VfsNodeOps};
 use alloc::collections::VecDeque;

--- a/kernel/twilight_kernel/src/driver/mod.rs
+++ b/kernel/twilight_kernel/src/driver/mod.rs
@@ -6,6 +6,7 @@ pub mod keyboard;
 pub mod mouse;
 pub mod nic;
 pub mod pci_device_driver;
+pub mod time;
 pub mod timer;
 pub mod uart;
 pub mod usb;

--- a/kernel/twilight_kernel/src/driver/time/clocksource.rs
+++ b/kernel/twilight_kernel/src/driver/time/clocksource.rs
@@ -1,0 +1,170 @@
+//! Generic fixed-point cycle-to-nanosecond clocksource converter.
+//!
+//! A [`ClockSource`] holds the epoch counter value and the multiplier/shift pair
+//! used to convert elapsed hardware cycles into nanoseconds:
+//!
+//! ```text
+//! elapsed_cycles = (now_cycles - epoch_cycles) mod 2^64
+//! elapsed_ns     = (elapsed_cycles * mult) >> shift
+//! ```
+//!
+//! This is deliberately free of any x86 specifics so that it can be unit-tested
+//! in isolation and reused by a future HPET or paravirtual (kvm-clock) backend.
+//!
+//! The conversion mirrors the scheme used by Linux's `struct clocksource`:
+//! `mult`/`shift` are precomputed at calibration time so the hot read path is a
+//! single multiply + shift, with a `u128` intermediate to avoid overflow.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// Continuously advancing counter that answers "what time is it?".
+///
+/// A `ClockSource` does **not** depend on interrupt delivery. Reading the
+/// underlying hardware counter (TSC, HPET, ...) and calling [`elapsed_ns`]
+/// yields elapsed nanoseconds regardless of how many timer IRQs were delivered.
+#[derive(Debug)]
+pub struct ClockSource {
+    /// Counter value captured at boot; elapsed time is measured relative to it.
+    epoch_cycles: u64,
+    /// `elapsed_ns = (elapsed_cycles * mult) >> shift`.
+    mult: u64,
+    shift: u32,
+    /// Nominal frequency in Hz, kept for diagnostics only.
+    freq_hz: u64,
+    /// Last value returned by [`elapsed_ns`], used to enforce monotonic
+    /// non-decrease across readers on CPUs whose counters are not perfectly
+    /// synchronized. Cheap and correct; irrelevant on a single CPU today.
+    last_ns: AtomicU64,
+}
+
+impl ClockSource {
+    /// Build a clocksource from calibrated conversion parameters.
+    pub const fn new(epoch_cycles: u64, mult: u64, shift: u32, freq_hz: u64) -> Self {
+        Self {
+            epoch_cycles,
+            mult,
+            shift,
+            freq_hz,
+            last_ns: AtomicU64::new(0),
+        }
+    }
+
+    /// Nominal counter frequency in Hz (diagnostics).
+    pub fn frequency_hz(&self) -> u64 {
+        self.freq_hz
+    }
+
+    /// Convert a raw counter reading into elapsed nanoseconds since the epoch.
+    ///
+    /// The subtraction is wrapping so a counter that wraps at `u64::MAX` (TSC at
+    /// ~years for GHz rates) is handled correctly. The `u128` multiply cannot
+    /// overflow for any realistic elapsed window. Round-to-nearest is applied
+    /// (the standard Linux `clocksource_cyc2ns` scheme) so truncation does not
+    /// accumulate a rate error.
+    pub fn elapsed_ns(&self, now_cycles: u64) -> u64 {
+        let delta = now_cycles.wrapping_sub(self.epoch_cycles);
+        let raw = (delta as u128) * (self.mult as u128);
+        let ns = if self.shift == 0 {
+            raw
+        } else {
+            (raw + (1u128 << (self.shift - 1))) >> self.shift
+        };
+        let ns = core::cmp::min(ns, u64::MAX as u128) as u64;
+
+        // Guarantee non-decreasing reads. `fetch_max` is a single locked RMW on
+        // x86; on a single-CPU system this is effectively free.
+        let prev = self.last_ns.fetch_max(ns, Ordering::AcqRel);
+        core::cmp::max(ns, prev)
+    }
+}
+
+/// Compute a `mult`/`shift` pair so that `(cycles * mult) >> shift == ns`
+/// for a counter running at `freq_hz`.
+///
+/// We want `ns = cycles * 1_000_000_000 / freq_hz`. Choosing `shift` as large
+/// as possible while keeping `mult` within `u64` maximizes precision. This is
+/// the standard clocksource calibration helper.
+pub fn compute_mult_shift(freq_hz: u64) -> (u64, u32) {
+    const NSEC_PER_SEC: u128 = 1_000_000_000;
+
+    if freq_hz == 0 {
+        return (0, 0);
+    }
+
+    // Find the largest shift such that mult = (NSEC_PER_SEC << shift) / freq_hz
+    // still fits in u64. Start from a generous shift and back off.
+    let mut shift: u32 = 32;
+    while shift > 0 {
+        let mult = ((NSEC_PER_SEC << shift) + (freq_hz as u128) / 2) / (freq_hz as u128);
+        if mult <= u64::MAX as u128 {
+            return (mult as u64, shift);
+        }
+        shift -= 1;
+    }
+    // shift == 0: ns = cycles * 1e9 / freq_hz, truncated. Only reached for
+    // absurdly high frequencies; still correct, just lower precision.
+    let mult = (NSEC_PER_SEC + (freq_hz as u128) / 2) / (freq_hz as u128);
+    (mult as u64, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cs_for_freq(freq_hz: u64) -> ClockSource {
+        let (mult, shift) = compute_mult_shift(freq_hz);
+        ClockSource::new(0, mult, shift, freq_hz)
+    }
+
+    #[test]
+    fn exact_frequency_conversion() {
+        // 1 GHz: 1 cycle == 1 ns.
+        let cs = cs_for_freq(1_000_000_000);
+        assert_eq!(cs.elapsed_ns(1_000_000_000), 1_000_000_000);
+        assert_eq!(cs.elapsed_ns(1_000), 1_000);
+    }
+
+    #[test]
+    fn submicrosecond_rounding() {
+        // 3 GHz: 3 cycles == 1 ns.
+        let cs = cs_for_freq(3_000_000_000);
+        // 3 cycles -> 1 ns
+        assert_eq!(cs.elapsed_ns(3), 1);
+        // 3000 cycles -> 1000 ns
+        assert_eq!(cs.elapsed_ns(3000), 1000);
+    }
+
+    #[test]
+    fn epoch_offset() {
+        let (mult, shift) = compute_mult_shift(1_000_000_000);
+        let cs = ClockSource::new(1_000_000, mult, shift, 1_000_000_000);
+        // 1e6 cycles after epoch == 1e6 ns.
+        assert_eq!(cs.elapsed_ns(2_000_000), 1_000_000);
+    }
+
+    #[test]
+    fn counter_wrap() {
+        let (mult, shift) = compute_mult_shift(1_000_000_000);
+        let cs = ClockSource::new(u64::MAX - 100, mult, shift, 1_000_000_000);
+        // 200 cycles elapsed across the wrap == 200 ns.
+        assert_eq!(cs.elapsed_ns(100), 200);
+    }
+
+    #[test]
+    fn monotonic_non_decrease() {
+        let cs = cs_for_freq(1_000_000_000);
+        let a = cs.elapsed_ns(500);
+        let b = cs.elapsed_ns(400); // hypothetical backward TSC read
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn long_duration_no_overflow() {
+        let cs = cs_for_freq(3_000_000_000);
+        // ~1 year of cycles at 3 GHz.
+        let one_year_cycles = 3_000_000_000u64 * 60 * 60 * 24 * 365;
+        let ns = cs.elapsed_ns(one_year_cycles);
+        let secs = ns / 1_000_000_000;
+        assert!((secs as u128) > 31_000_000 && (secs as u128) < 32_000_000);
+    }
+}

--- a/kernel/twilight_kernel/src/driver/time/mod.rs
+++ b/kernel/twilight_kernel/src/driver/time/mod.rs
@@ -28,9 +28,14 @@ use crate::task::executor::halt;
 
 const NSEC_PER_SEC: u64 = 1_000_000_000;
 
-/// The selected hardware clocksource. `OnceCell` because it is initialized once
-/// at boot and read on every time read; reads are lock-free after init.
+/// The TSC clocksource, when available. `None` (and `TSC_AVAILABLE = false`)
+/// on QEMU TCG, where the TSC is not a valid clocksource.
 static CLOCKSOURCE: OnceCell<clocksource::ClockSource> = OnceCell::uninit();
+
+/// Whether the TSC clocksource was successfully initialized. When false,
+/// `monotonic_ns()` falls back to the interrupt-count clocksource.
+static TSC_AVAILABLE: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 
 /// Boot-time offset such that `CLOCK_REALTIME = offset + CLOCK_MONOTONIC`.
 /// Established once from the CMOS RTC; the RTC is used only for the epoch, never
@@ -38,60 +43,86 @@ static CLOCKSOURCE: OnceCell<clocksource::ClockSource> = OnceCell::uninit();
 static REALTIME_OFFSET_NS: AtomicU64 = AtomicU64::new(0);
 static OFFSET_INITED: AtomicU64 = AtomicU64::new(0); // 0 = no, 1 = yes
 
-/// Diagnostic counter of delivered timer events. **Not** the timeline. Kept
-/// only so boot diagnostics can compare IRQ count against clocksource elapsed
-/// time; never used to derive `CLOCK_MONOTONIC`.
+/// Counter of delivered timer events. Under KVM/bare metal this is diagnostic
+/// only; the TSC is the clocksource. Under QEMU TCG this counter **is** the
+/// clocksource, because TCG delivers every scheduled interrupt (no coalescing)
+/// so one event == one tick period.
 static TIMER_EVENTS: AtomicU64 = AtomicU64::new(0);
+
+/// Nanoseconds per timer event (tick period). The LAPIC timer is calibrated to
+/// 1 kHz, so each event represents 1 ms. Used by the TCG fallback clocksource.
+const NS_PER_TIMER_EVENT: u64 = 1_000_000;
 
 /// Initialize the clocksource. Must run once during boot, before any time read.
 ///
-/// On x86_64 this detects the invariant TSC and calibrates it. Failing to
-/// initialize is fatal because every consumer (logs, sleeps, scheduler,
-/// syscalls) depends on a working timeline.
+/// On x86_64 this tries the invariant TSC first. Under QEMU TCG (no KVM) the
+/// TSC is not a valid clocksource (it advances at host real time while the
+/// LAPIC/PIT advance at QEMU virtual time, so the two diverge during idle); in
+/// that case we fall back to the interrupt-count clocksource, which is correct
+/// under TCG because TCG delivers every interrupt.
 pub fn init() {
-    let tsc = tsc::detect().expect("no usable clocksource: TSC frequency unavailable");
+    match tsc::detect() {
+        Some(tsc) => {
+            let invariant = tsc.is_invariant();
+            let freq = tsc.frequency_hz();
+            let freq_source = tsc.frequency_source();
+            let usable = tsc.usable_as_clocksource();
 
-    let invariant = tsc.is_invariant();
-    let freq = tsc.frequency_hz();
-    let freq_source = tsc.frequency_source();
+            // Always publish the TSC frequency for timer::wait and LAPIC
+            // calibration, even when the TSC is not usable as the clocksource.
+            tsc::publish_frequency(freq);
 
-    if invariant {
-        crate::serial_println!(
-            "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=true freq={} Hz source={}",
-            freq,
-            freq_source,
-        );
-    } else {
-        // The TSC is usable but CPUID did not advertise it as invariant. On
-        // real hardware this means the TSC may stop in deep C-states; under
-        // software emulation (TCG) there are no real C-states so it is correct.
-        crate::serial_println!(
-            "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=false freq={} Hz source={} \
-             (warning: TSC not advertised invariant; time may drift in deep sleep on bare metal)",
-            freq,
-            freq_source,
-        );
+            if usable {
+                if invariant {
+                    crate::serial_println!(
+                        "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=true freq={} Hz source={}",
+                        freq,
+                        freq_source,
+                    );
+                } else {
+                    crate::serial_println!(
+                        "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=false freq={} Hz source={} \
+                         (warning: TSC not advertised invariant; time may drift in deep sleep on bare metal)",
+                        freq,
+                        freq_source,
+                    );
+                }
+                let _ = CLOCKSOURCE.try_init_once(|| tsc.into_source());
+                TSC_AVAILABLE.store(true, Ordering::Release);
+            } else {
+                // TCG: TSC frequency is calibrated for timer::wait/LAPIC, but
+                // the TSC is not the clocksource. Fall back to interrupt count.
+                crate::serial_println!(
+                    "\x1b[93m[time]\x1b[0m clocksource=tick freq={} Hz source={} \
+                     (TCG: TSC calibrated for delays but not usable as clocksource; using interrupt-count)",
+                    freq,
+                    freq_source,
+                );
+            }
+        }
+        None => {
+            // No TSC frequency at all. Fall back to the interrupt-count clocksource.
+            crate::serial_println!(
+                "\x1b[93m[time]\x1b[0m clocksource=tick (TSC unavailable; using interrupt-count fallback)"
+            );
+        }
     }
-
-    tsc::publish_frequency(freq);
-
-    // `detect()` already captured the epoch at calibration time; store that
-    // ClockSource as-is so elapsed_ns is near-zero at boot.
-    let _ = CLOCKSOURCE.try_init_once(|| tsc.into_source());
 }
 
 /// Continuously advancing monotonic nanoseconds since boot.
 ///
-/// Lock-free, allocation-free, and safe to call from any context including the
-/// timer ISR. Does not depend on interrupt delivery.
+/// Under KVM/bare metal this reads the TSC clocksource and does not depend on
+/// interrupt delivery. Under QEMU TCG it falls back to counting delivered timer
+/// events (correct there because TCG does not coalesce interrupts).
 #[inline]
 pub fn monotonic_ns() -> u64 {
-    let Some(cs) = CLOCKSOURCE.get() else {
-        // Before init: no time has elapsed. Returning 0 keeps early-boot
-        // consumers (e.g. the log macro) functional.
-        return 0;
-    };
-    cs.elapsed_ns(tsc::read_cycles())
+    if TSC_AVAILABLE.load(Ordering::Acquire) {
+        if let Some(cs) = CLOCKSOURCE.get() {
+            return cs.elapsed_ns(tsc::read_cycles());
+        }
+    }
+    // TCG fallback: each delivered timer event is one tick period.
+    TIMER_EVENTS.load(Ordering::Relaxed) * NS_PER_TIMER_EVENT
 }
 
 /// Wall-clock nanoseconds since the Unix epoch (`CLOCK_REALTIME`).

--- a/kernel/twilight_kernel/src/driver/time/mod.rs
+++ b/kernel/twilight_kernel/src/driver/time/mod.rs
@@ -1,0 +1,220 @@
+//! Kernel timekeeping: the system timeline, decoupled from interrupt delivery.
+//!
+//! This module owns `CLOCK_MONOTONIC` and `CLOCK_REALTIME`. The monotonic
+//! timeline is read from a continuously advancing hardware clocksource (the
+//! invariant TSC on x86_64), **not** from a count of delivered timer interrupts.
+//!
+//! This is the root-cause fix for #62: under KVM, periodic LAPIC interrupts can
+//! be delayed or coalesced while the vCPU is descheduled, so an interrupt-count
+//! clock permanently loses elapsed time. Reading the TSC instead means host
+//! descheduling no longer erases guest time.
+//!
+//! Timer interrupts are now pure *clock events*: they drive scheduler ticks and
+//! deadline expiry via [`handle_timer_event`], but they do not advance the
+//! timeline. The two responsibilities are separated, as Linux and FreeBSD do.
+
+pub mod clocksource;
+pub mod tsc;
+
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
+
+use conquer_once::spin::OnceCell;
+
+use twilight_common::syscall::types::{EFAULT, EINVAL, Timespec};
+
+use crate::driver::timer::cmos::CMOS;
+use crate::task::executor::halt;
+
+const NSEC_PER_SEC: u64 = 1_000_000_000;
+
+/// The selected hardware clocksource. `OnceCell` because it is initialized once
+/// at boot and read on every time read; reads are lock-free after init.
+static CLOCKSOURCE: OnceCell<clocksource::ClockSource> = OnceCell::uninit();
+
+/// Boot-time offset such that `CLOCK_REALTIME = offset + CLOCK_MONOTONIC`.
+/// Established once from the CMOS RTC; the RTC is used only for the epoch, never
+/// for elapsed-time progression.
+static REALTIME_OFFSET_NS: AtomicU64 = AtomicU64::new(0);
+static OFFSET_INITED: AtomicU64 = AtomicU64::new(0); // 0 = no, 1 = yes
+
+/// Diagnostic counter of delivered timer events. **Not** the timeline. Kept
+/// only so boot diagnostics can compare IRQ count against clocksource elapsed
+/// time; never used to derive `CLOCK_MONOTONIC`.
+static TIMER_EVENTS: AtomicU64 = AtomicU64::new(0);
+
+/// Initialize the clocksource. Must run once during boot, before any time read.
+///
+/// On x86_64 this detects the invariant TSC and calibrates it. Failing to
+/// initialize is fatal because every consumer (logs, sleeps, scheduler,
+/// syscalls) depends on a working timeline.
+pub fn init() {
+    let tsc = tsc::detect().expect("no usable clocksource: TSC frequency unavailable");
+
+    let invariant = tsc.is_invariant();
+    let freq = tsc.frequency_hz();
+    let freq_source = tsc.frequency_source();
+
+    if invariant {
+        crate::serial_println!(
+            "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=true freq={} Hz source={}",
+            freq,
+            freq_source,
+        );
+    } else {
+        // The TSC is usable but CPUID did not advertise it as invariant. On
+        // real hardware this means the TSC may stop in deep C-states; under
+        // software emulation (TCG) there are no real C-states so it is correct.
+        crate::serial_println!(
+            "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=false freq={} Hz source={} \
+             (warning: TSC not advertised invariant; time may drift in deep sleep on bare metal)",
+            freq,
+            freq_source,
+        );
+    }
+
+    tsc::publish_frequency(freq);
+
+    // `detect()` already captured the epoch at calibration time; store that
+    // ClockSource as-is so elapsed_ns is near-zero at boot.
+    let _ = CLOCKSOURCE.try_init_once(|| tsc.into_source());
+}
+
+/// Continuously advancing monotonic nanoseconds since boot.
+///
+/// Lock-free, allocation-free, and safe to call from any context including the
+/// timer ISR. Does not depend on interrupt delivery.
+#[inline]
+pub fn monotonic_ns() -> u64 {
+    let Some(cs) = CLOCKSOURCE.get() else {
+        // Before init: no time has elapsed. Returning 0 keeps early-boot
+        // consumers (e.g. the log macro) functional.
+        return 0;
+    };
+    cs.elapsed_ns(tsc::read_cycles())
+}
+
+/// Wall-clock nanoseconds since the Unix epoch (`CLOCK_REALTIME`).
+#[inline]
+pub fn realtime_ns() -> u64 {
+    REALTIME_OFFSET_NS
+        .load(Ordering::Relaxed)
+        .saturating_add(monotonic_ns())
+}
+
+/// Establish the realtime epoch from the CMOS RTC.
+///
+/// Called once at boot. The RTC defines the wall-clock origin; monotonic elapsed
+/// time thereafter comes from the clocksource, so realtime no longer inherits
+/// interrupt-count drift.
+pub fn init_realtime_offset_from_cmos() {
+    let cmos_secs: u64 = CMOS::new().unix_time();
+    let realtime_ns = cmos_secs.saturating_mul(NSEC_PER_SEC);
+    let mono_ns = monotonic_ns() as u128;
+
+    // REALTIME = OFFSET + MONOTONIC  =>  OFFSET = REALTIME - MONOTONIC
+    let offset = (realtime_ns as u128).saturating_sub(mono_ns);
+    REALTIME_OFFSET_NS.store(offset as u64, Ordering::Relaxed);
+    OFFSET_INITED.store(1, Ordering::Relaxed);
+}
+
+/// Clock-event handler invoked by the timer ISR.
+///
+/// This advances scheduler state and expires deadlines; it does **not** advance
+/// the timeline. The timeline is read from the clocksource on demand. Renamed
+/// from the old `pit_tick_isr` to make clear that a delivered interrupt is an
+/// event, not a unit of time.
+pub fn handle_timer_event() {
+    TIMER_EVENTS.fetch_add(1, Ordering::Relaxed);
+    crate::sys::proc::on_timer_tick();
+}
+
+/// Diagnostic: number of timer events delivered since boot.
+pub fn timer_event_count() -> u64 {
+    TIMER_EVENTS.load(Ordering::Relaxed)
+}
+
+// ---------------------------------------------------------------------------
+// Sleeping
+// ---------------------------------------------------------------------------
+
+/// Block the current task until `nanoseconds` of monotonic time have elapsed.
+///
+/// This still uses a `sti; hlt` loop keyed on [`monotonic_ns`], which is now
+/// correct because the deadline is measured against the TSC. Replacing this with
+/// a deadline-ordered timer wait queue (so a sleeping task is not woken once per
+/// intermediate tick) is tracked as a separate follow-up in #62 (Phase 3).
+pub fn sleep_ns(nanoseconds: u64) {
+    if nanoseconds == 0 {
+        return;
+    }
+
+    let start = monotonic_ns();
+    let deadline = start.saturating_add(nanoseconds);
+
+    while monotonic_ns() < deadline {
+        halt();
+        crate::sys::preempt::cond_resched();
+    }
+}
+
+/// Validate and execute a relative `nanosleep`/`clock_nanosleep` request.
+pub fn sleep_timespec(req: &Timespec) -> Result<(), i64> {
+    if req.tv_sec < 0 || req.tv_nsec < 0 || req.tv_nsec >= (NSEC_PER_SEC as i64) {
+        return Err(-(EINVAL as i64));
+    }
+
+    let secs = req.tv_sec as u128;
+    let nsec = req.tv_nsec as u128;
+    let total = secs
+        .saturating_mul(NSEC_PER_SEC as u128)
+        .saturating_add(nsec);
+
+    sleep_ns(core::cmp::min(total, u64::MAX as u128) as u64);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CLOCK_* policy and clock_gettime
+// ---------------------------------------------------------------------------
+
+pub const CLOCK_REALTIME: i32 = 0;
+pub const CLOCK_MONOTONIC: i32 = 1;
+
+pub fn sys_clock_gettime(clockid: i32, tp: *mut Timespec) -> i64 {
+    if tp.is_null() {
+        return -(EFAULT as i64);
+    }
+
+    if OFFSET_INITED.load(Ordering::Relaxed) == 0 {
+        init_realtime_offset_from_cmos();
+    }
+
+    let ns: u64 = match clockid {
+        CLOCK_MONOTONIC => monotonic_ns(),
+        CLOCK_REALTIME => realtime_ns(),
+        _ => return -(EINVAL as i64),
+    };
+
+    unsafe {
+        (*tp).tv_sec = (ns / NSEC_PER_SEC) as i64;
+        (*tp).tv_nsec = (ns % NSEC_PER_SEC) as i64;
+    }
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Uptime helpers (used by logs, procfs, drivers)
+// ---------------------------------------------------------------------------
+
+/// Monotonic uptime as a `Duration`.
+pub fn uptime_duration() -> Duration {
+    let ns = monotonic_ns();
+    Duration::new(ns / NSEC_PER_SEC, (ns % NSEC_PER_SEC) as u32)
+}
+
+/// Monotonic uptime in seconds as `f64`, for log timestamps and legacy callers.
+pub fn uptime_secs_f64() -> f64 {
+    let ns = monotonic_ns();
+    (ns / NSEC_PER_SEC) as f64 + ((ns % NSEC_PER_SEC) as f64) / 1e9
+}

--- a/kernel/twilight_kernel/src/driver/time/tsc.rs
+++ b/kernel/twilight_kernel/src/driver/time/tsc.rs
@@ -10,7 +10,7 @@
 //! This is the root-cause fix for #62: elapsed time is read from the TSC, not
 //! from a count of delivered timer interrupts.
 
-use raw_cpuid::CpuId;
+use raw_cpuid::{CpuId, Hypervisor};
 
 use super::clocksource::{compute_mult_shift, ClockSource};
 
@@ -25,6 +25,11 @@ pub struct TscClock {
     freq_source: &'static str,
     /// Whether CPUID advertised an invariant TSC.
     invariant: bool,
+    /// Whether the TSC is usable as the system clocksource. False under QEMU
+    /// TCG, where the TSC advances at host real time while LAPIC/PIT advance at
+    /// QEMU virtual time. The frequency is still calibrated (for `timer::wait`
+    /// and LAPIC calibration) even when this is false.
+    usable_as_clocksource: bool,
 }
 
 impl TscClock {
@@ -42,6 +47,12 @@ impl TscClock {
 
     pub fn is_invariant(&self) -> bool {
         self.invariant
+    }
+
+    /// Whether the TSC should be used as the system clocksource. False under
+    /// TCG; the caller falls back to the interrupt-count clocksource.
+    pub fn usable_as_clocksource(&self) -> bool {
+        self.usable_as_clocksource
     }
 
     /// Consume the backend, yielding the calibrated clocksource for storage.
@@ -134,8 +145,26 @@ fn has_rdtscp() -> bool {
 /// Returns `None` only if no frequency could be determined. On the reported KVM
 /// `-cpu host` configuration the TSC is invariant and CPUID.15h is available, so
 /// path 1 is taken.
+///
+/// Returns `None` only if no frequency could be determined. Even under QEMU
+/// TCG (where the TSC is not usable as the system clocksource) the frequency is
+/// still calibrated and returned, because `timer::wait` and LAPIC calibration
+/// need a TSC frequency for short busy-waits. The caller checks
+/// `usable_as_clocksource()` to decide whether to use the TSC as the clocksource
+/// or fall back to the interrupt-count clocksource.
 pub fn detect() -> Option<TscClock> {
     let cpuid = CpuId::new();
+
+    // Under QEMU TCG (no KVM), the TSC advances at host real time while the
+    // LAPIC/PIT advance at QEMU virtual time. During `hlt` (idle), the virtual
+    // clock pauses but the host TSC keeps going, so the TSC-based clock would
+    // run fast. TCG delivers every interrupt (no coalescing), so the interrupt
+    // count is a valid clocksource there. We still calibrate the TSC frequency
+    // (for timer::wait and LAPIC calibration) but mark it unusable as clocksource.
+    let is_tcg = cpuid
+        .get_hypervisor_info()
+        .map(|h| matches!(h.identify(), Hypervisor::QEMU))
+        .unwrap_or(false);
 
     // Probe rdtscp once and cache it for the hot read path.
     let rdtscp = cpuid
@@ -186,6 +215,7 @@ pub fn detect() -> Option<TscClock> {
         source,
         freq_source,
         invariant,
+        usable_as_clocksource: !is_tcg,
     })
 }
 

--- a/kernel/twilight_kernel/src/driver/time/tsc.rs
+++ b/kernel/twilight_kernel/src/driver/time/tsc.rs
@@ -1,0 +1,272 @@
+//! x86_64 invariant-TSC clocksource backend.
+//!
+//! The invariant TSC is a continuously advancing counter that advances at a
+//! fixed rate independent of CPU power state and (with `nonstop_tsc`) continues
+//! to advance while the logical CPU is in C-states. Under KVM with `-cpu host`
+//! on a host advertising `constant_tsc` + `nonstop_tsc` + `arat`, the TSC is
+//! the correct virtualized clocksource: it advances with real elapsed time even
+//! when the vCPU is descheduled and periodic LAPIC interrupts are coalesced.
+//!
+//! This is the root-cause fix for #62: elapsed time is read from the TSC, not
+//! from a count of delivered timer interrupts.
+
+use raw_cpuid::CpuId;
+
+use super::clocksource::{compute_mult_shift, ClockSource};
+
+/// Minimum TSC frequency (1 kHz) below which calibration is treated as failed.
+const MIN_FREQ_HZ: u64 = 1_000;
+
+/// A calibrated invariant-TSC clocksource.
+#[derive(Debug)]
+pub struct TscClock {
+    source: ClockSource,
+    /// How the frequency was obtained, for boot diagnostics.
+    freq_source: &'static str,
+    /// Whether CPUID advertised an invariant TSC.
+    invariant: bool,
+}
+
+impl TscClock {
+    pub fn source(&self) -> &ClockSource {
+        &self.source
+    }
+
+    pub fn frequency_hz(&self) -> u64 {
+        self.source.frequency_hz()
+    }
+
+    pub fn frequency_source(&self) -> &'static str {
+        self.freq_source
+    }
+
+    pub fn is_invariant(&self) -> bool {
+        self.invariant
+    }
+
+    /// Consume the backend, yielding the calibrated clocksource for storage.
+    pub fn into_source(self) -> ClockSource {
+        self.source
+    }
+}
+
+/// The calibrated TSC frequency in Hz, or 0 before [`super::init`] has run.
+///
+/// Stored separately from the `ClockSource` so legacy callers (`timer::wait`,
+/// procfs MHz display) can reach it without holding a reference to the
+/// `OnceCell`-stored clocksource.
+static TSC_FREQ_HZ: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+/// Publish the calibrated TSC frequency for legacy callers. Called once by
+/// [`super::init`].
+pub(crate) fn publish_frequency(hz: u64) {
+    TSC_FREQ_HZ.store(hz, core::sync::atomic::Ordering::Release);
+}
+
+/// Calibrated TSC frequency in Hz (0 before init).
+pub fn frequency_hz() -> u64 {
+    TSC_FREQ_HZ.load(core::sync::atomic::Ordering::Acquire)
+}
+
+/// Read the current TSC value with serialization.
+///
+/// `rdtscp` is preferred when available because it serializes the instruction
+/// stream (no out-of-order read). Otherwise we use `lfence; rdtsc`, matching the
+/// pattern already used elsewhere in the kernel.
+#[inline]
+pub fn read_cycles() -> u64 {
+    if has_rdtscp() {
+        // SAFETY: rdtscp is a userspace-safe, non-privileged instruction. The
+        // `ecx` output (auxiliary TSC info) is discarded.
+        let lo: u32;
+        let hi: u32;
+        unsafe {
+            core::arch::asm!(
+                "rdtscp",
+                out("eax") lo,
+                out("edx") hi,
+                out("ecx") _,
+                options(nostack, preserves_flags, readonly),
+            );
+        }
+        ((hi as u64) << 32) | (lo as u64)
+    } else {
+        // SAFETY: lfence + rdtsc. lfence ensures prior instructions complete
+        // before the TSC is read; rdtsc is non-privileged.
+        let lo: u32;
+        let hi: u32;
+        unsafe {
+            core::arch::asm!(
+                "lfence",
+                "rdtsc",
+                out("eax") lo,
+                out("edx") hi,
+                options(nostack, preserves_flags, readonly),
+            );
+        }
+        ((hi as u64) << 32) | (lo as u64)
+    }
+}
+
+/// Whether `rdtscp` is available. Probed once during [`detect`] and stored in
+/// an atomic so the hot [`read_cycles`] path is a single relaxed load.
+static HAS_RDTSCP: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+fn has_rdtscp() -> bool {
+    HAS_RDTSCP.load(core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Detect and calibrate a TSC clocksource.
+///
+/// The TSC is used whenever a frequency can be determined. The CPUID "invariant
+/// TSC" flag is a *quality* guarantee (the TSC does not stop in deep C-states),
+/// not a usability requirement: under software emulation (TCG) there are no real
+/// C-states, so the TSC advances correctly even when the flag is absent. We
+/// therefore do not refuse to boot when the flag is unset; we only log a warning
+/// so the operator knows the clock may drift on real hardware that lacks it.
+///
+/// Frequency is resolved, in order of preference, by:
+///  1. CPUID leaf 0x15 (`TscInfo::tsc_frequency()`) — exact, no measurement.
+///  2. CPUID leaf 0x16 processor base frequency (MHz → Hz).
+///  3. PIT-calibrated measurement against a known wall interval (cycle count,
+///     **not** interrupt count).
+///
+/// Returns `None` only if no frequency could be determined. On the reported KVM
+/// `-cpu host` configuration the TSC is invariant and CPUID.15h is available, so
+/// path 1 is taken.
+pub fn detect() -> Option<TscClock> {
+    let cpuid = CpuId::new();
+
+    // Probe rdtscp once and cache it for the hot read path.
+    let rdtscp = cpuid
+        .get_extended_processor_and_feature_identifiers()
+        .map(|f| f.has_rdtscp())
+        .unwrap_or(false);
+    HAS_RDTSCP.store(rdtscp, core::sync::atomic::Ordering::Release);
+
+    let invariant = cpuid
+        .get_advanced_power_mgmt_info()
+        .map(|a| a.has_invariant_tsc())
+        .unwrap_or(false);
+
+    // Resolve the TSC frequency, most-reliable source first:
+    //  1. Hypervisor paravirtual TSC frequency (KVM leaf 0x40000010, exact kHz).
+    //     This is the best source under KVM, where CPUID 0x15/0x16 are often
+    //     unavailable (e.g. AMD hosts) and PIT calibration is less precise.
+    //  2. CPUID leaf 0x15 (TscInfo::tsc_frequency()) — exact, no measurement.
+    //  3. CPUID leaf 0x16 processor base frequency (MHz → Hz).
+    //  4. PIT-calibrated measurement (fallback; see calibrate_with_pit).
+    let (freq_hz, freq_source) = cpuid
+        .get_hypervisor_info()
+        .and_then(|h| h.tsc_frequency())
+        .filter(|&khz| khz > 0)
+        .map(|khz| (khz as u64 * 1_000, "kvm.0x40000010"))
+        .or_else(|| {
+            cpuid
+                .get_tsc_info()
+                .and_then(|t| t.tsc_frequency())
+                .map(|f| (f, "cpuid.0x15"))
+        })
+        .or_else(|| {
+            cpuid
+                .get_processor_frequency_info()
+                .map(|p| (p.processor_base_frequency() as u64 * 1_000_000, "cpuid.0x16"))
+        })
+        .unwrap_or_else(|| (calibrate_with_pit(), "pit-calibration"));
+
+    if freq_hz < MIN_FREQ_HZ {
+        return None;
+    }
+
+    let (mult, shift) = compute_mult_shift(freq_hz);
+    let epoch = read_cycles();
+    let source = ClockSource::new(epoch, mult, shift, freq_hz);
+
+    Some(TscClock {
+        source,
+        freq_source,
+        invariant,
+    })
+}
+
+/// Calibrate the TSC frequency by counting TSC cycles over a PIT-measured
+/// interval, using the PIT **counter latch** rather than the output pulse.
+///
+/// Reading the PIT's down-counter (via the read-latch command) gives a stable
+/// wall-clock reference that does not depend on interrupt delivery and is not a
+/// transient signal the vCPU can miss while descheduled. This mirrors Linux's
+/// `pit_verify_tsc` approach. It is the fallback when CPUID does not enumerate
+/// the TSC frequency directly (e.g. KVM `-cpu host` on AMD, where leaves
+/// 0x15/0x16 are unsupported and the paravirtual leaf 0x40000010 is not exposed).
+///
+/// We program channel 2 in mode 2 (rate generator) with a large divisor, then
+/// sample (TSC, PIT-count) twice. The PIT counts down at PIT_BASE_HZ; the
+/// difference in counts (handling the modular wrap at the divisor) gives the
+/// elapsed PIT ticks, and the TSC difference gives the elapsed cycles.
+fn calibrate_with_pit() -> u64 {
+    use x86_64::instructions::port::Port;
+
+    const PIT_BASE_HZ: u64 = 1_193_182;
+    // Large divisor so the counter rarely wraps during the measurement window.
+    // 65535 gives ~55 ms per full countdown.
+    const PIT_DIVISOR: u16 = 0xFFFF;
+
+    unsafe {
+        let mut cmd: Port<u8> = Port::new(0x43);
+        let mut ch2: Port<u8> = Port::new(0x42);
+        let mut port_b: Port<u8> = Port::new(0x61);
+
+        // Channel 2, mode 2 (rate generator), lo/hi access, binary.
+        cmd.write(0xb4);
+        ch2.write((PIT_DIVISOR & 0xff) as u8);
+        ch2.write((PIT_DIVISOR >> 8) as u8);
+
+        // Enable channel 2 gate (bit 0), disable speaker (bit 1).
+        let saved_b = port_b.read();
+        port_b.write((saved_b & !0x02) | 0x01);
+
+        // First sample.
+        let tsc0 = read_cycles();
+        let pit0 = read_ch2_count(&mut cmd, &mut ch2);
+
+        // Spin ~20 ms by counting PIT down-ticks. The counter wraps modulo
+        // PIT_DIVISOR+1, so use wrapping subtraction to get the elapsed count.
+        let mut pit1 = pit0;
+        let mut tsc1 = tsc0;
+        // Target ~20 ms = ~23864 PIT ticks at 1.193 MHz.
+        const TARGET_TICKS: u32 = 23_864;
+        for _ in 0..1_000_000 {
+            pit1 = read_ch2_count(&mut cmd, &mut ch2);
+            let elapsed = (pit0.wrapping_sub(pit1)) & 0xFFFF;
+            if elapsed >= TARGET_TICKS {
+                tsc1 = read_cycles();
+                break;
+            }
+        }
+
+        // Restore port B.
+        port_b.write(saved_b);
+
+        let pit_delta = ((pit0.wrapping_sub(pit1)) & 0xFFFF) as u64;
+        let tsc_delta = tsc1.wrapping_sub(tsc0);
+        if pit_delta == 0 || tsc_delta == 0 {
+            return 0;
+        }
+        // tsc_hz = tsc_delta * PIT_BASE_HZ / pit_delta
+        tsc_delta * PIT_BASE_HZ / pit_delta
+    }
+}
+
+/// Read the PIT channel 2 current count via the read-latch command.
+///
+/// The counter counts *down*, so a smaller reading means more time has elapsed.
+/// We issue the latch command then read two bytes (lo then hi).
+unsafe fn read_ch2_count(cmd: &mut x86_64::instructions::port::Port<u8>, ch2: &mut x86_64::instructions::port::Port<u8>) -> u32 {
+    // Latch channel 2 count (read-back without disturbing operation).
+    unsafe {
+        cmd.write(0x80);
+        let lo = ch2.read() as u32;
+        let hi = ch2.read() as u32;
+        (hi << 8) | lo
+    }
+}

--- a/kernel/twilight_kernel/src/driver/timer/mod.rs
+++ b/kernel/twilight_kernel/src/driver/timer/mod.rs
@@ -1,39 +1,50 @@
-use core::sync::atomic::{AtomicU64, Ordering};
+//! Timer hardware subsystem.
+//!
+//! The system timeline lives in [`crate::driver::time`], read from the
+//! invariant-TSC clocksource. This module retains only:
+//!  - the PIT hardware setup ([`pit`]) used for early boot clock events and as a
+//!    calibration reference, and
+//!  - the CMOS RTC ([`cmos`]) used for the realtime epoch.
+//!
+//! Historically this module also calibrated the TSC by sleeping on the
+//! interrupt-count clock. That calibration is removed: the TSC frequency is now
+//! resolved from CPUID (or, as a fallback, a PIT-cycle measurement that does not
+//! depend on interrupt delivery) in [`crate::driver::time::tsc`]. See #62.
 
 pub mod cmos;
 pub mod pit;
 
-static TSC_FREQUENCY: AtomicU64 = AtomicU64::new(0);
-
-/// Calibrated TSC ticks per microsecond.
+/// Calibrated TSC ticks per microsecond, for legacy callers (ATA/USB nanosecond
+/// busy-waits and procfs MHz display). Delegates to the clocksource frequency.
 pub fn tsc_frequency() -> u64 {
-    TSC_FREQUENCY.load(Ordering::Relaxed)
+    // The clocksource stores Hz; cycles/us = Hz / 1_000_000.
+    crate::driver::time::tsc::frequency_hz() / 1_000_000
 }
 
+/// Read the current TSC value (serialized). Delegates to the clocksource backend.
 pub fn tsc() -> u64 {
-    unsafe {
-        core::arch::x86_64::_mm_lfence();
-        core::arch::x86_64::_rdtsc()
-    }
+    crate::driver::time::tsc::read_cycles()
 }
 
+/// Initialize the PIT hardware. The TSC clocksource is initialized separately
+/// by [`crate::driver::time::init`]; this function no longer calibrates the TSC
+/// by sleeping on the (now-removed) interrupt-count clock.
 pub fn init() {
-    pit::init(); // Set PIT to 1000Hz (1ms) before calibration
-    let calibration_time = 250_000; // 0.25 seconds
-    let a = tsc();
-    crate::task::executor::sleep(calibration_time as f64 / 1e6);
-    let b = tsc();
-    TSC_FREQUENCY.store((b - a) / calibration_time, Ordering::Relaxed);
+    pit::init();
 }
 
+/// Busy-wait approximately `nanoseconds` using the TSC.
+///
+/// This is a spin-wait used for short hardware delays (ATA PIO timing, USB
+/// frame intervals). It counts TSC cycles, not interrupts, so it is unaffected
+/// by the #62 coalescing defect. Ceiling division keeps sub-microsecond waits
+/// from collapsing to zero.
 pub fn wait(nanoseconds: u64) {
     let ticks_per_microsecond = tsc_frequency();
     if nanoseconds == 0 || ticks_per_microsecond == 0 {
         return;
     }
 
-    // The calibration stores cycles/us. Convert ns to cycles with ceiling
-    // division so sub-microsecond ATA timing waits never collapse to zero.
     let delta = ((nanoseconds as u128 * ticks_per_microsecond as u128) + 999) / 1_000;
     let delta = core::cmp::min(delta, u64::MAX as u128) as u64;
     let start = tsc();

--- a/kernel/twilight_kernel/src/driver/timer/pit.rs
+++ b/kernel/twilight_kernel/src/driver/timer/pit.rs
@@ -1,23 +1,20 @@
-use crate::driver::timer::cmos::CMOS;
-use crate::task::executor::halt;
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use core::time::Duration;
-use twilight_common::syscall::types::{EFAULT, EINVAL, Timespec};
+//! PIT (8253/8254) hardware: clock-event and calibration reference only.
+//!
+//! The PIT no longer owns the system timeline. `CLOCK_MONOTONIC` is read from
+//! the invariant-TSC clocksource in [`crate::driver::time`]. The PIT is used
+//! here only to program channel 0 (the legacy timer interrupt source used during
+//! early boot and as a calibration reference) and as a wall-clock reference for
+//! TSC frequency calibration.
+//!
+//! See issue #62 for why interrupt-count timekeeping was removed.
 
-// We are now using APIC timer at 1000Hz (1ms)
-const NSEC_PER_SEC: u64 = 1_000_000_000;
-const FREQ_HZ: u64 = 1_000;
-
-const NUM_NS_PER_TICK: u128 = (NSEC_PER_SEC as u128) / (FREQ_HZ as u128);
-const DEN_NS_PER_TICK: u128 = 1;
-
-static TICKS: AtomicU64 = AtomicU64::new(0);
-
-static REALTIME_OFFSET_NS: AtomicUsize = AtomicUsize::new(0);
-static OFFSET_INITED: AtomicU64 = AtomicU64::new(0); // 0 = no, 1 = yes
-
+/// Program PIT channel 0 to a 1 kHz square wave (1 ms period).
+///
+/// Channel 0 is the legacy IRQ0 source. During boot it drives timer events
+/// until the LAPIC timer takes over; afterwards IRQ0 is masked. The divisor
+/// `1193182 / 1000 = 1193` yields ~1 kHz with a ~0.015% rate error, which is
+/// negligible for a calibration reference and irrelevant to the TSC clocksource.
 pub fn init() {
-    // 1193182 / 1000 = 1193
     let divisor: u16 = 1193;
     unsafe {
         use x86_64::instructions::port::Port;
@@ -29,103 +26,4 @@ pub fn init() {
         data.write((divisor & 0xFF) as u8);
         data.write((divisor >> 8) as u8);
     }
-}
-
-pub fn pit_tick_isr() {
-    TICKS.fetch_add(1, Ordering::Relaxed);
-    crate::sys::proc::on_timer_tick();
-}
-
-#[inline]
-fn monotonic_ns() -> u128 {
-    let t = TICKS.load(Ordering::Relaxed) as u128;
-    (t * NUM_NS_PER_TICK) / DEN_NS_PER_TICK
-}
-
-pub fn monotonic_ns_u64() -> u64 {
-    core::cmp::min(monotonic_ns(), u64::MAX as u128) as u64
-}
-
-pub fn sleep_ns(nanoseconds: u64) {
-    if nanoseconds == 0 {
-        return;
-    }
-
-    let start = monotonic_ns_u64();
-    let deadline = start.saturating_add(nanoseconds);
-
-    while monotonic_ns_u64() < deadline {
-        halt();
-        crate::sys::preempt::cond_resched();
-    }
-}
-
-pub fn sleep_timespec(req: &Timespec) -> Result<(), i64> {
-    if req.tv_sec < 0 || req.tv_nsec < 0 || req.tv_nsec >= (NSEC_PER_SEC as i64) {
-        return Err(-(EINVAL as i64));
-    }
-
-    let secs = req.tv_sec as u128;
-    let nsec = req.tv_nsec as u128;
-    let total = secs
-        .saturating_mul(NSEC_PER_SEC as u128)
-        .saturating_add(nsec);
-
-    sleep_ns(core::cmp::min(total, u64::MAX as u128) as u64);
-    Ok(())
-}
-
-pub fn init_realtime_offset_from_cmos() {
-    // CMOS wall clock in seconds since Unix epoch
-    let cmos_secs: u64 = CMOS::new().unix_time();
-    let realtime_ns = (cmos_secs as u128) * (NSEC_PER_SEC as u128);
-    let mono_ns = monotonic_ns();
-
-    // REALTIME = OFFSET + MONOTONIC  =>  OFFSET = REALTIME - MONOTONIC
-    let offset = realtime_ns.saturating_sub(mono_ns);
-    REALTIME_OFFSET_NS.store(offset as usize, Ordering::Relaxed);
-    OFFSET_INITED.store(1, Ordering::Relaxed);
-}
-
-pub const CLOCK_REALTIME: i32 = 0;
-pub const CLOCK_MONOTONIC: i32 = 1;
-
-pub fn sys_clock_gettime(clockid: i32, tp: *mut Timespec) -> i64 {
-    if tp.is_null() {
-        return -(EFAULT as i64);
-    }
-
-    // Lazy-init offset if you prefer not to call init at boot
-    if OFFSET_INITED.load(Ordering::Relaxed) == 0 {
-        init_realtime_offset_from_cmos();
-    }
-
-    let ns: u128 = match clockid {
-        CLOCK_MONOTONIC => monotonic_ns(),
-        CLOCK_REALTIME => {
-            let off = REALTIME_OFFSET_NS.load(Ordering::Relaxed);
-            off.saturating_add(monotonic_ns() as usize) as u128
-        }
-        _ => return -EINVAL as i64,
-    };
-
-    unsafe {
-        (*tp).tv_sec = (ns / (NSEC_PER_SEC as u128)) as i64;
-        (*tp).tv_nsec = (ns % (NSEC_PER_SEC as u128)) as i64;
-    }
-    0
-}
-
-pub fn uptime_duration() -> Duration {
-    let t = TICKS.load(Ordering::Relaxed) as u128;
-    let ns = (t * NUM_NS_PER_TICK) / DEN_NS_PER_TICK;
-    let secs = (ns / (NSEC_PER_SEC as u128)) as u64;
-    let nsec = (ns % (NSEC_PER_SEC as u128)) as u32;
-    Duration::new(secs, nsec)
-}
-
-// optional: if you still want a f64 seconds helper
-pub fn uptime() -> f64 {
-    let d = uptime_duration();
-    d.as_secs() as f64 + (d.subsec_nanos() as f64) / 1e9
 }

--- a/kernel/twilight_kernel/src/driver/usb/keyboard.rs
+++ b/kernel/twilight_kernel/src/driver/usb/keyboard.rs
@@ -1,5 +1,5 @@
 use crate::driver::keyboard::keyboard_interrupt;
-use crate::driver::timer::pit::monotonic_ns_u64;
+use crate::driver::time::monotonic_ns as monotonic_ns_u64;
 use crate::driver::usb::interfaces::{
     HostController, InterruptTransfer, UsbDevice, UsbDriver, UsbError,
 };

--- a/kernel/twilight_kernel/src/driver/usb/xhci/xhci.rs
+++ b/kernel/twilight_kernel/src/driver/usb/xhci/xhci.rs
@@ -946,7 +946,7 @@ impl XhciDriver {
 
                 // Poll manually (ISR is disabled)
                 self.poll_event_ring();
-                crate::driver::timer::pit::sleep_ns(10);
+                crate::driver::time::sleep_ns(10);
                 waited_us += 10;
             }
         });

--- a/kernel/twilight_kernel/src/kernel_utils/dhcp.rs
+++ b/kernel/twilight_kernel/src/kernel_utils/dhcp.rs
@@ -1,5 +1,5 @@
 use crate::driver::timer::cmos::CMOS;
-use crate::driver::timer::pit::uptime;
+use crate::driver::time::uptime_secs_f64 as uptime;
 use crate::println;
 use crate::sys::net::socket::SOCKETS;
 use crate::task::executor::sleep;

--- a/kernel/twilight_kernel/src/main.rs
+++ b/kernel/twilight_kernel/src/main.rs
@@ -238,10 +238,22 @@ pub fn init(
     arch::x86_64::syscall::init();
 
     x86_64::instructions::interrupts::enable();
+
+    // Initialize the clocksource before anything that reads time or calibrates
+    // against it. The TSC clocksource is detected from CPUID (no IRQs needed)
+    // and publishes the TSC frequency used by `timer::wait` and LAPIC
+    // calibration below. This must precede `timer::init` and `lapic::init`.
+    driver::time::init();
+
     driver::timer::init();
 
-    // Switch to APIC timer
+    // Switch to APIC timer. Calibration busy-waits on the TSC, not on the
+    // interrupt-count clock, so it is correct under KVM (#62).
     driver::apic::lapic::init();
+
+    // Establish the realtime epoch from the CMOS RTC. The RTC defines the
+    // wall-clock origin; elapsed time thereafter comes from the TSC clocksource.
+    driver::time::init_realtime_offset_from_cmos();
 
     // Mask PIT (IRQ0) to prevent double ticks
     unsafe {
@@ -257,7 +269,7 @@ pub fn init(
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => ({
-        let time = $crate::driver::timer::pit::uptime();
+        let time = $crate::driver::time::uptime_secs_f64();
         $crate::sys::kmsg::push_log(format_args!("[{:.6}] {}", time, format_args!($($arg)*)));
         $crate::serial_println!("\x1b[93m[{:.6}]\x1b[0m {}", time, format_args!($($arg)*));
     });
@@ -266,7 +278,7 @@ macro_rules! log {
 #[macro_export]
 macro_rules! logger {
     ($($arg:tt)*) => ({
-        let time = $crate::driver::timer::pit::uptime();
+        let time = $crate::driver::time::uptime_secs_f64();
         $crate::sys::kmsg::push_log(format_args!("[{:.6}] {}", time, format_args!($($arg)*)));
         $crate::serial_println!("\x1b[93m[{:.6}]\x1b[0m {}", time, format_args!($($arg)*));
     });

--- a/kernel/twilight_kernel/src/sys/console/tty.rs
+++ b/kernel/twilight_kernel/src/sys/console/tty.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use crate::driver::keyboard::KeyboardListener;
-use crate::driver::timer::pit::uptime_duration;
+use crate::driver::time::uptime_duration;
 use crate::sys::console::TTY;
 use crate::sys::console::framebuffer::FramebufferTerminal;
 use crate::sys::fs::vfs::{BlockDev, VfsNodeOps};

--- a/kernel/twilight_kernel/src/sys/framebuffer/mod.rs
+++ b/kernel/twilight_kernel/src/sys/framebuffer/mod.rs
@@ -1,5 +1,5 @@
 use crate::arch::x86_64::io::delay;
-use crate::driver::timer::pit::uptime;
+use crate::driver::time::uptime_secs_f64 as uptime;
 use crate::sys::fs::vfs::{BlockDev, VfsNodeOps};
 use crate::sys::memory::map_kernel_buffer;
 use crate::sys::proc::mem::{PAGE, align_up};

--- a/kernel/twilight_kernel/src/sys/fs/mod.rs
+++ b/kernel/twilight_kernel/src/sys/fs/mod.rs
@@ -49,7 +49,7 @@ pub enum VfsError {
 }
 
 pub fn init(show_log: bool) {
-    let uptime = crate::driver::timer::pit::uptime();
+    let uptime = crate::driver::time::uptime_secs_f64();
     for _ in 0..16 {
         #[allow(static_mut_refs)]
         let usb_ready = unsafe { USB_BLOCK_DEVICE.is_some() };
@@ -174,7 +174,7 @@ fn try_init_usb_storage(show_log: bool) -> bool {
             if show_log {
                 println!(
                     "\x1b[93m[{:.6}]\x1b[0m USB media left unchanged: {}",
-                    crate::driver::timer::pit::uptime(),
+                    crate::driver::time::uptime_secs_f64(),
                     err
                 );
             }
@@ -207,7 +207,7 @@ fn try_init_usb_storage(show_log: bool) -> bool {
         if show_log {
             println!(
                 "\x1b[93m[{:.6}]\x1b[0m USB storage mounted at /mnt/usb",
-                crate::driver::timer::pit::uptime()
+                crate::driver::time::uptime_secs_f64()
             );
         }
     };
@@ -291,7 +291,7 @@ fn try_mount_live_image(
     if show_log {
         println!(
             "\x1b[93m[{:.6}]\x1b[0m Live system mounted from {}",
-            crate::driver::timer::pit::uptime(),
+            crate::driver::time::uptime_secs_f64(),
             source
         );
     }
@@ -336,7 +336,7 @@ fn try_mount_boot(bus: u8, dsk: u8, show_log: bool) -> bool {
             if show_log {
                 println!(
                     "\x1b[93m[{:.6}]\x1b[0m FAT32 partition mounted at /boot from ATA {}:{} (LBA {})",
-                    crate::driver::timer::pit::uptime(),
+                    crate::driver::time::uptime_secs_f64(),
                     bus,
                     dsk,
                     entry_lba
@@ -356,7 +356,7 @@ fn try_mount_boot(bus: u8, dsk: u8, show_log: bool) -> bool {
             if show_log {
                 println!(
                     "\x1b[93m[{:.6}]\x1b[0m FAT16 partition mounted at /boot from ATA {}:{} (LBA {})",
-                    crate::driver::timer::pit::uptime(),
+                    crate::driver::time::uptime_secs_f64(),
                     bus,
                     dsk,
                     entry_lba

--- a/kernel/twilight_kernel/src/sys/fs/procfs/nodes.rs
+++ b/kernel/twilight_kernel/src/sys/fs/procfs/nodes.rs
@@ -1,4 +1,4 @@
-use crate::driver::timer::pit;
+use crate::driver::time;
 use crate::sys::fs::vfs::BlockDev;
 use crate::sys::fs::vfs::VfsNodeOps;
 use alloc::format;
@@ -101,7 +101,7 @@ fn build_meminfo() -> String {
 }
 
 fn build_uptime() -> String {
-    let up = pit::uptime();
+    let up = time::uptime_secs_f64();
     // Linux: "<uptime_seconds> <idle_seconds>\n"
     // We don't track idle time yet -> 0.00.
     format!("{:.2} {:.2}\n", up, 0.00)

--- a/kernel/twilight_kernel/src/sys/pci/mod.rs
+++ b/kernel/twilight_kernel/src/sys/pci/mod.rs
@@ -1,4 +1,4 @@
-use crate::driver::timer::pit::uptime;
+use crate::driver::time::uptime_secs_f64 as uptime;
 use crate::println;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/kernel/twilight_kernel/src/sys/proc/mod.rs
+++ b/kernel/twilight_kernel/src/sys/proc/mod.rs
@@ -1897,8 +1897,9 @@ fn switch_by_index_guarded(
 }
 
 fn timer_preempt_common(frame: *mut PreemptFrame, from_user: u64) -> *mut PreemptFrame {
-    // need_resched is already set by on_timer_tick() (called via pit_tick_isr
-    // before this function). The logic below decides whether to act on it now.
+    // need_resched is already set by on_timer_tick() (called via
+    // driver::time::handle_timer_event before this function). The logic below
+    // decides whether to act on it now.
 
     // Existing safe path: interrupted userspace → schedule immediately.
     if from_user != 0 {
@@ -1931,7 +1932,7 @@ fn timer_preempt_common(frame: *mut PreemptFrame, from_user: u64) -> *mut Preemp
 
 pub extern "C" fn timer_preempt(frame: *mut PreemptFrame, from_user: u64) -> *mut PreemptFrame {
     crate::sys::preempt::irq_enter();
-    crate::driver::timer::pit::pit_tick_isr();
+    crate::driver::time::handle_timer_event();
 
     // EOI for IRQ0 (PIC timer)
     unsafe {
@@ -1949,7 +1950,7 @@ pub extern "C" fn apic_timer_preempt(
     from_user: u64,
 ) -> *mut PreemptFrame {
     crate::sys::preempt::irq_enter();
-    crate::driver::timer::pit::pit_tick_isr();
+    crate::driver::time::handle_timer_event();
 
     // EOI for Local APIC
     crate::driver::apic::lapic::end_of_interrupt();

--- a/kernel/twilight_kernel/src/sys/rng.rs
+++ b/kernel/twilight_kernel/src/sys/rng.rs
@@ -2,7 +2,7 @@ use crate::log;
 
 use crate::driver::disk::ata::{FileIO, IO};
 use crate::driver::timer::cmos::CMOS;
-use crate::driver::timer::pit::uptime;
+use crate::driver::time::uptime_secs_f64 as uptime;
 use lazy_static::lazy_static;
 use rand::{RngCore, SeedableRng};
 use rand_hc::Hc128Rng;

--- a/kernel/twilight_kernel/src/sys/syscall/mod.rs
+++ b/kernel/twilight_kernel/src/sys/syscall/mod.rs
@@ -232,7 +232,7 @@ pub extern "sysv64" fn syscall_handler(
                     };
                 }
 
-                match crate::driver::timer::pit::sleep_timespec(req) {
+                match crate::driver::time::sleep_timespec(req) {
                     Ok(()) => 0i64,
                     Err(e) => e, // negative errno
                 }
@@ -252,7 +252,7 @@ pub extern "sysv64" fn syscall_handler(
         SYS_SETTID_ADDR => crate::sys::proc::id() as i64,
         SYS_CLOCK_GETTIME => {
             let timespec_ptr = arg2 as *mut Timespec;
-            crate::driver::timer::pit::sys_clock_gettime(arg1 as i32, timespec_ptr)
+            crate::driver::time::sys_clock_gettime(arg1 as i32, timespec_ptr)
         }
         SYS_CLOCK_NANOSLEEP => {
             const TIMER_ABSTIME: i32 = 1;
@@ -290,13 +290,13 @@ pub extern "sysv64" fn syscall_handler(
                     }
 
                     if flags & TIMER_ABSTIME == 0 {
-                        match crate::driver::timer::pit::sleep_timespec(&req) {
+                        match crate::driver::time::sleep_timespec(&req) {
                             Ok(()) => 0,
                             Err(errno) => errno,
                         }
                     } else {
                         let mut now = Timespec::default();
-                        let now_res = crate::driver::timer::pit::sys_clock_gettime(
+                        let now_res = crate::driver::time::sys_clock_gettime(
                             clockid,
                             &mut now as *mut Timespec,
                         );
@@ -312,7 +312,7 @@ pub extern "sysv64" fn syscall_handler(
                             if req_ns <= now_ns {
                                 0
                             } else {
-                                crate::driver::timer::pit::sleep_ns(
+                                crate::driver::time::sleep_ns(
                                     core::cmp::min(
                                         (req_ns - now_ns) as u128,
                                         u64::MAX as u128,

--- a/kernel/twilight_kernel/src/sys/syscall/service.rs
+++ b/kernel/twilight_kernel/src/sys/syscall/service.rs
@@ -1,6 +1,6 @@
 use crate::arch::x86_64::io::{IA32_FS_BASE, rdmsr, wrmsr};
 use crate::driver::disk::ata::IO;
-use crate::driver::timer::pit::uptime;
+use crate::driver::time::uptime_secs_f64 as uptime;
 use crate::sys::fs::memfd::MemFd;
 use crate::sys::fs::pipe::make_pipe_ends;
 use crate::sys::fs::vfs::{FileType, VFS};
@@ -4995,7 +4995,7 @@ pub fn sysinfo(info_ptr: usize) -> i64 {
         return -(EFAULT as i64);
     }
 
-    let uptime_secs = crate::driver::timer::pit::uptime() as i64;
+    let uptime_secs = crate::driver::time::uptime_secs_f64() as i64;
 
     let total_pages: usize;
     let free_pages: usize;

--- a/kernel/twilight_kernel/src/task/executor.rs
+++ b/kernel/twilight_kernel/src/task/executor.rs
@@ -16,8 +16,8 @@ pub fn init_executor() {
 }
 
 pub fn sleep(duration: f64) {
-    let start = crate::driver::timer::pit::uptime();
-    while crate::driver::timer::pit::uptime() - start < duration {
+    let start = crate::driver::time::uptime_secs_f64();
+    while crate::driver::time::uptime_secs_f64() - start < duration {
         halt();
     }
 }

--- a/userspace/apps/clockcheck/Makefile
+++ b/userspace/apps/clockcheck/Makefile
@@ -1,0 +1,20 @@
+CC ?= musl-gcc
+CFLAGS ?= -O2 -static -Wall -Wextra
+
+BIN := clockcheck
+SRC_DIR := src
+SRCS := $(wildcard $(SRC_DIR)/*.c)
+OBJS := $(SRCS:.c=.o)
+
+.PHONY: all clean install
+
+all: $(BIN)
+
+$(SRC_DIR)/%.o: $(SRC_DIR)/%.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BIN): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f $(BIN) $(OBJS)

--- a/userspace/apps/clockcheck/src/main.c
+++ b/userspace/apps/clockcheck/src/main.c
@@ -1,0 +1,91 @@
+/*
+ * clockcheck — verify CLOCK_MONOTONIC tracks real elapsed time.
+ *
+ * Reads CLOCK_MONOTONIC before and after a nanosleep, prints the requested
+ * vs measured interval in nanoseconds, and the drift ratio. Also runs a
+ * busy-wait segment to detect a slow clock. Output is machine-readable so it
+ * can be diffed against host wall time in regression tests (issue #62).
+ *
+ * Usage: clockcheck [sleep_ms]
+ *
+ * Default sleep is 1000 ms. Prints lines like:
+ *   sleep req_ns=1000000000 meas_ns=1002003456 drift_ppm=2003
+ */
+
+#define _POSIX_C_SOURCE 200809L
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+static uint64_t now_ns(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0;
+    }
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+static long parse_long(const char *s) {
+    long v = 0;
+    while (*s >= '0' && *s <= '9') {
+        v = v * 10 + (*s - '0');
+        s++;
+    }
+    return v;
+}
+
+int main(int argc, char **argv) {
+    long sleep_ms = 1000;
+    if (argc >= 2) {
+        sleep_ms = parse_long(argv[1]);
+        if (sleep_ms <= 0) sleep_ms = 1000;
+    }
+
+    uint64_t req_ns = (uint64_t)sleep_ms * 1000000ULL;
+
+    /* --- sleep accuracy test --- */
+    uint64_t t0 = now_ns();
+    struct timespec req = { .tv_sec = sleep_ms / 1000,
+                           .tv_nsec = (sleep_ms % 1000) * 1000000L };
+    nanosleep(&req, NULL);
+    uint64_t t1 = now_ns();
+    uint64_t meas_ns = t1 - t0;
+
+    int64_t drift_ppm;
+    if (req_ns == 0) {
+        drift_ppm = 0;
+    } else {
+        /* drift in parts per million, positive = clock slow (measured > requested) */
+        drift_ppm = (int64_t)((meas_ns - req_ns) * 1000000ULL / req_ns);
+    }
+
+    printf("sleep req_ns=%llu meas_ns=%llu drift_ppm=%lld\n",
+           (unsigned long long)req_ns,
+           (unsigned long long)meas_ns,
+           (long long)drift_ppm);
+
+    /* --- monotonicity test: two rapid reads must not go backwards --- */
+    uint64_t a = now_ns();
+    uint64_t b = now_ns();
+    if (b < a) {
+        printf("monotonicity FAIL a=%llu b=%llu\n",
+               (unsigned long long)a, (unsigned long long)b);
+        return 1;
+    }
+    printf("monotonicity OK\n");
+
+    /* --- busy-wait drift: 200 ms of CPU work, clock should advance ~200 ms --- */
+    uint64_t w0 = now_ns();
+    volatile uint64_t sink = 0;
+    uint64_t target = 200 * 1000000ULL;
+    while (now_ns() - w0 < target) {
+        for (int i = 0; i < 1000; i++) sink += i;
+    }
+    uint64_t w1 = now_ns();
+    printf("busy req_ns=%llu meas_ns=%llu\n",
+           (unsigned long long)target,
+           (unsigned long long)(w1 - w0));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #62 — `CLOCK_MONOTONIC` loses time when KVM coalesces periodic LAPIC interrupts.

### Root cause

`CLOCK_MONOTONIC` was derived from a counter incremented once per delivered timer interrupt (`TICKS` in `driver/timer/pit.rs`). Under KVM, periodic LAPIC interrupts can be delayed or coalesced while the vCPU is descheduled, so delivered interrupts ≠ elapsed milliseconds and time permanently disappears. The controlled test in the issue (5s `SIGSTOP` of the QEMU process) lost ~4 seconds of guest time.

### The fix

Separates the **clocksource** (the timeline) from **clock events** (interrupts), as Linux and FreeBSD do:

- **New `driver/time/` module** owns `CLOCK_MONOTONIC`/`CLOCK_REALTIME`, reading elapsed time from the invariant TSC via a fixed-point cycles→ns converter ([`clocksource.rs`](kernel/twilight_kernel/src/driver/time/clocksource.rs)) and an x86_64 TSC backend ([`tsc.rs`](kernel/twilight_kernel/src/driver/time/tsc.rs)).
- **Timer interrupts become pure clock events** via `handle_timer_event()`; they drive scheduler ticks but no longer advance the timeline.
- **`pit.rs` slimmed** to PIT hardware init only; the `TICKS` counter, timeline, sleeps, and `clock_gettime` move to `driver::time`.
- **LAPIC calibration** busy-waits on the TSC instead of `pit::sleep_ns`, fixing the boot-time miscalibration defect.
- **All ~20 consumers** repointed from `pit::uptime`/`sleep_*` to `driver::time`.

### TSC frequency resolution

Order of preference: KVM paravirtual leaf `0x40000010` → CPUID `0x15` → CPUID `0x16` → PIT counter-latch calibration (fallback).

The PIT latch-based calibration reads a stable down-counter (via the read-latch command) rather than the transient output pulse, so it is robust under KVM descheduling. On the reported AMD host the first three CPUID sources are unavailable, so the PIT latch path is used.

### Verification — the #62 host-starvation test

Ran the exact reproduction from the issue: `SIGSTOP` the QEMU process for 5 seconds, then resume.

```
before stop:  events=6000 uptime=6.033s
host pause  = 5.003s
after resume: events=8000 uptime=13.035s
```

Guest uptime advanced **7.0s** (5s pause + 2s active) while only **2 interrupts** were delivered. **Time is no longer lost.** Before the fix, uptime would have advanced only ~2s, permanently losing 5 seconds.

The calibrated frequency is **2.7952 GHz**, within 0.02% of the host's measured 2.7947 GHz.

### Tests

- New `clockcheck` userspace utility (issue Phase 0) prints `CLOCK_MONOTONIC` deltas around `nanosleep` and busy-wait with drift-in-PPM output for machine-readable regression testing.
- Unit tests in `clocksource.rs` for the fixed-point conversion (exact frequency, sub-microsecond rounding, epoch offset, counter wrap, monotonic non-decrease, long-duration overflow). The conversion math was also verified on-host.

### Out of scope (separate follow-ups per the issue)

- Deadline-ordered timer queue / `ProcessState::Sleeping` sleep (Phase 3) — `sleep_ns` still uses a `sti;hlt` loop, now keyed on the correct TSC clock.
- Removing per-tick `POLL_WAIT_QUEUE.notify_all()` (Phase 4).
- LAPIC one-shot / TSC-deadline mode; kvm-clock backend.

### Note on TCG (no `-enable-kvm`)

Under TCG the guest TSC is virtualized (advances with emulated instructions, not host wall time), so the clock runs fast. This is a TCG-only artifact — the #62 report is KVM-specific, and the KVM path is now correct.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added calibrated monotonic timekeeping for more accurate uptime, sleeps, clock reads, and event timing.
  * Added realtime clock support initialized from the hardware clock.
  * Added the `clockcheck` utility to measure sleep accuracy, detect clock drift, and verify monotonic timestamps.
* **Bug Fixes**
  * Improved timer calibration by measuring actual elapsed time instead of relying on interrupt counts.
  * Unified timing across system services, device drivers, scheduling, and clock-related system calls.
  * Added reliable fallback timing support when hardware clock sources are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->