### PR TITLE
fix(time): replace TCG interrupt-count fallback with HPET clocksource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /.zig-cache
 /rootfs/bin
 /rootfs/sbin
+/tools/time-regression/logs/*
+/.claude/plans/*
 twilight_kernel/kernel
 kernel/twilight_kernel/kernel
 twilight-os.iso

--- a/docs/timekeeping.md
+++ b/docs/timekeeping.md
@@ -1,0 +1,85 @@
+# Timekeeping
+
+Twilight's kernel timekeeping owns `CLOCK_MONOTONIC` and `CLOCK_REALTIME`. The
+monotonic timeline is read from a **continuously advancing hardware clocksource**,
+never from a count of delivered timer interrupts.
+
+## Why this matters
+
+A periodic LAPIC interrupt is a *clock event*, not an elapsed-time source. Under
+QEMU TCG (and under KVM when the vCPU is descheduled), periodic interrupts can be
+delayed or coalesced while `IF` is clear. Deriving `CLOCK_MONOTONIC` from
+`delivered_timer_events * tick_period` permanently loses elapsed time whenever an
+interrupt is late or merged. This was the root cause of issues #62 and #65.
+
+The fix separates the two responsibilities, as Linux and FreeBSD do:
+
+- **Clocksource** — answers "what time is it?" by reading a free-running hardware
+  counter (TSC or HPET). Never depends on interrupt delivery.
+- **Clock event** — a delivered timer IRQ drives scheduler ticks and deadline
+  expiry via `handle_timer_event()`. It does **not** advance the timeline.
+
+## Clocksource selection
+
+Selection runs once at boot (`driver::time::init()`), after memory/MMIO support
+is ready and ACPI tables are cached, and before interrupts are enabled:
+
+1. **Validated invariant/paravirtual TSC** — selected when CPUID advertises an
+   invariant TSC (`CPUID.80000007:EDX[8]`) **or** a paravirtual KVM TSC frequency
+   (leaf `0x40000010`) is present. KVM guarantees the TSC advances with real
+   elapsed time even when the vCPU is descheduled, so a paravirtual frequency is
+   both a frequency source and a stability signal.
+2. **HPET** — selected when the TSC is not validated as stable (e.g. under QEMU
+   TCG). The HPET main counter is discovered through ACPI, mapped device/uncached,
+   enabled, and proven to advance before selection.
+3. **Explicit failure** — if neither backend validates, time-service
+   initialization panics with an explicit message. There is **no silent
+   interrupt-count fallback**.
+
+Calibration alone (PIT counter-latch measurement, or `CPUID.0x16` base
+frequency) is **not** a stability guarantee: under QEMU TCG the TSC advances at
+host real time while the LAPIC/PIT advance at QEMU virtual time, so a
+calibrated-only TSC diverges during `hlt`. The hypervisor vendor is explicitly
+not used as a clock-quality test.
+
+## Invariants
+
+- `monotonic_ns()` advances without timer IRQ delivery and never moves backward
+  (enforced by a `fetch_max` on the last returned nanosecond value).
+- Clocksource reads never depend on delivered interrupt count.
+- `CLOCK_REALTIME` is the boot-time RTC offset plus corrected monotonic time.
+  Twilight does not yet implement `clock_settime`.
+- Late clock-event IRQs do not lose elapsed time.
+- The hot read path is lock-free and allocation-free; no MMIO mapping occurs
+  after initialization.
+
+## HPET backend
+
+The HPET MMIO block is discovered via the cached ACPI tables
+(`acpi::hpet::HpetInfo`), not a hardcoded address. It is mapped through
+`sys::memory::map_mmio()`, which forces device/uncached page flags (updating any
+pre-existing HHDM write-back mapping). The implementation:
+
+- Reads capabilities at `+0x000`, configuration at `+0x010`, main counter at
+  `+0x0F0`.
+- Extracts the counter period in femtoseconds from capability bits 63:32 and
+  converts it to nanoseconds via a wide multiply-before-divide rational
+  converter (`compute_mult_shift_period`), preserving full femtosecond precision
+  rather than rounding to a lossy integer Hz first.
+- Requires a 64-bit counter (32-bit-only counters are rejected explicitly).
+- Preserves unrelated general-configuration bits when setting `ENABLE_CNF`.
+- Captures the counter epoch without resetting an already-active consumer.
+- Proves the counter advances before selecting it.
+
+## Testing
+
+The regression harness under `tools/time-regression/` boots the live ISO across
+a QEMU matrix (TCG/KVM, several CPU models, SMP counts) and verifies that
+monotonic time passes during idle, CPU load, temporarily masked timer IRQs, and
+delayed vCPU execution — and that the delivered-event count can diverge from
+monotonic time without losing elapsed time.
+
+## Out of scope
+
+NTP, `clock_settime`, suspend/resume, SMP TSC synchronization, HPET comparator
+interrupts, and scheduler sleeping.

--- a/kernel/twilight_kernel/src/driver/time/hpet.rs
+++ b/kernel/twilight_kernel/src/driver/time/hpet.rs
@@ -1,0 +1,328 @@
+//! HPET (High Precision Event Timer) clocksource backend.
+//!
+//! Used as the continuously readable monotonic clocksource when the TSC is not
+//! validated as a stable clocksource (e.g. under QEMU TCG, where the TSC advances
+//! at host real time while the LAPIC/PIT advance at QEMU virtual time). The HPET
+//! main counter is a free-running 64-bit counter that advances at a fixed
+//! hardware rate independent of interrupt delivery, so it does not lose elapsed
+//! time when timer IRQs are coalesced or delayed.
+//!
+//! This is the root-cause fix for #65: the previous TCG fallback derived
+//! `CLOCK_MONOTONIC` from `delivered_timer_events * 1ms`, which permanently lost
+//! time whenever a periodic LAPIC interrupt was late or coalesced. The HPET
+//! counter is read directly and never depends on interrupt count.
+//!
+//! ## Register layout (offsets from the MMIO base)
+//!  - `0x000` General Capabilities / ID
+//!  - `0x010` General Configuration
+//!  - `0x0f0` Main Counter (64-bit)
+//!
+//! Capabilities bits: counter period in femtoseconds = bits 63:32; `CNT_64BIT`
+//! = bit 13. Configuration bit 0 = `ENABLE_CNF` (start the main counter).
+
+use core::ptr::{read_volatile, write_volatile};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// HPET register offsets (bytes from the MMIO base).
+const REG_CAPABILITIES: usize = 0x000;
+const REG_CONFIG: usize = 0x010;
+const REG_MAIN_COUNTER: usize = 0x0f0;
+
+/// General Configuration bit: enable the main counter.
+const ENABLE_CNF: u64 = 1 << 0;
+/// Capabilities bit: 64-bit main counter.
+const CNT_64BIT: u64 = 1 << 13;
+
+/// The HPET register block fits within one 4 KiB page.
+const HPET_MMIO_SIZE: usize = 0x400;
+
+/// A calibrated HPET clocksource backend.
+///
+/// `base` is the kernel-virtual address of the HPET MMIO block (mapped
+/// device/uncached by [`map_mmio`](crate::sys::memory::map_mmio)). All reads in
+/// the hot path are a single aligned volatile u64 load of the main counter,
+/// followed by a wrapping subtract and a fixed-point multiply+shift — lock-free
+/// and allocation-free.
+#[derive(Debug)]
+pub struct HpetClock {
+    /// Kernel-virtual address of the HPET MMIO base register block.
+    base: *mut u64,
+    /// Counter value captured at boot; elapsed time is measured relative to it.
+    epoch: u64,
+    /// `elapsed_ns = (elapsed_cycles * mult) >> shift`, computed from the
+    /// femtosecond counter period without first rounding to an integer Hz.
+    mult: u64,
+    shift: u32,
+    /// Last value returned by [`read_ns`], enforcing monotonic non-decrease.
+    last_ns: AtomicU64,
+}
+
+// SAFETY: `HpetClock` holds a raw pointer to MMIO that is shared across CPUs but
+// accessed only through volatile reads/writes. The pointer refers to fixed
+// device memory that outlives the kernel. Reads are lock-free.
+unsafe impl Send for HpetClock {}
+unsafe impl Sync for HpetClock {}
+
+impl HpetClock {
+    /// Read the current monotonic nanosecond count.
+    ///
+    /// Lock-free and allocation-free: one volatile u64 read, a wrapping
+    /// subtract, a u128 multiply+shift, and a `fetch_max` for monotonicity.
+    #[inline]
+    pub fn read_ns(&self) -> u64 {
+        let now = self.read_counter();
+        let delta = now.wrapping_sub(self.epoch);
+        let raw = (delta as u128) * (self.mult as u128);
+        let ns = if self.shift == 0 {
+            raw
+        } else {
+            (raw + (1u128 << (self.shift - 1))) >> self.shift
+        };
+        let ns = core::cmp::min(ns, u64::MAX as u128) as u64;
+        let prev = self.last_ns.fetch_max(ns, Ordering::AcqRel);
+        core::cmp::max(ns, prev)
+    }
+
+    /// Raw read of the 64-bit main counter.
+    #[inline]
+    fn read_counter(&self) -> u64 {
+        // SAFETY: `base` points to the HPET MMIO block mapped as device memory.
+        // The main counter is at a fixed byte offset and is always safe to read.
+        unsafe { read_volatile(self.base.byte_add(REG_MAIN_COUNTER) as *const u64) }
+    }
+}
+
+/// Discover, map, enable, and validate an HPET clocksource.
+///
+/// Returns `None` if no HPET table is advertised, the counter is not 64-bit, the
+/// period is implausible, the counter does not advance, or the MMIO mapping
+/// fails. The caller then falls back to the next backend or fails explicitly.
+pub fn discover() -> Option<HpetClock> {
+    use acpi::hpet::HpetInfo;
+
+    let hpet = crate::sys::acpi::with_tables(|tables| HpetInfo::new(tables))
+        .and_then(|r| r.ok())?;
+
+    let phys_base = hpet.base_address as u64;
+    crate::sys::memory::map_mmio(phys_base, HPET_MMIO_SIZE).ok()?;
+
+    // The HHDM gives us a kernel-virtual address for this physical frame.
+    let base = crate::sys::memory::phys_to_virt(x86_64::PhysAddr::new(phys_base)).as_mut_ptr::<u64>();
+
+    // Build a temporary view to read capabilities and configure the counter.
+    let probe = HpetProbe { base };
+
+    // SAFETY: `base` points to the HPET MMIO block, mapped device/uncached by
+    // `map_mmio` above. All register accesses are aligned volatile u64 reads/writes
+    // at fixed offsets defined by the HPET specification.
+    let (period_fs, epoch) = unsafe {
+        let caps = probe.read_reg(REG_CAPABILITIES);
+        let period_fs = caps >> 32;
+
+        // Require a 64-bit counter. A 32-bit counter wraps too quickly (~4 s at
+        // 1 GHz) for a system monotonic clock without extension logic; reject it
+        // explicitly per #65 rather than silently producing a wrapping clock.
+        if caps & CNT_64BIT == 0 {
+            crate::serial_println!(
+                "\x1b[93m[time]\x1b[0m hpet: rejecting 32-bit-only counter (period={} fs)",
+                period_fs
+            );
+            return None;
+        }
+
+        // Validate the period. A period of 0 is malformed; a period above 1 second
+        // (10^15 fs) is implausible — the HPET specification mandates a minimum rate
+        // of ~10 Hz (max period 100 ms), so anything above 1 s is treated as broken.
+        if period_fs == 0 || period_fs > 1_000_000_000_000_000 {
+            crate::serial_println!(
+                "\x1b[93m[time]\x1b[0m hpet: rejecting implausible period={} fs",
+                period_fs
+            );
+            return None;
+        }
+
+        // Enable the main counter, preserving unrelated general-configuration bits.
+        let cfg = probe.read_reg(REG_CONFIG);
+        probe.write_reg(REG_CONFIG, cfg | ENABLE_CNF);
+
+        // Capture the epoch without resetting an already-active consumer. If the
+        // counter was already running (e.g. firmware left it enabled), we measure
+        // elapsed time relative to its current value rather than resetting it.
+        let epoch = probe.read_counter();
+
+        (period_fs, epoch)
+    };
+
+    // Prove the counter advances before selecting it. Spin briefly via the TSC
+    // (which advances per-cycle even under TCG) and re-read; a non-advancing
+    // counter would freeze guest time.
+    // SAFETY: same MMIO block as above.
+    let tsc0 = super::tsc::read_cycles();
+    let mut advanced = false;
+    // Wait up to ~1 ms of TSC cycles for the counter to tick.
+    let deadline = tsc0.saturating_add(super::tsc::frequency_hz().max(1_000) / 1_000);
+    while super::tsc::read_cycles() < deadline {
+        // SAFETY: reading the main counter is a fixed volatile MMIO load.
+        let now = unsafe { probe.read_counter() };
+        if now != epoch {
+            advanced = true;
+            break;
+        }
+    }
+    if !advanced {
+        crate::serial_println!("\x1b[93m[time]\x1b[0m hpet: counter does not advance, rejecting");
+        return None;
+    }
+
+    let (mult, shift) = compute_mult_shift_period(period_fs);
+
+    Some(HpetClock {
+        base,
+        epoch,
+        mult,
+        shift,
+        last_ns: AtomicU64::new(0),
+    })
+}
+
+/// Compute a `mult`/`shift` pair converting HPET counter ticks into nanoseconds,
+/// given the counter period in femtoseconds.
+///
+/// One counter tick equals `period_fs` femtoseconds; one nanosecond equals
+/// 10^6 femtoseconds, so `ns = cycles * period_fs / 10^6`. We choose the largest
+/// `shift` such that `mult = (period_fs << shift) / 10^6` fits in `u64`, then
+/// `elapsed_ns = (cycles * mult) >> shift`. This keeps the full femtosecond
+/// precision — it never rounds the period to a lossy integer Hz first.
+fn compute_mult_shift_period(period_fs: u64) -> (u64, u32) {
+    const FS_PER_NS: u128 = 1_000_000;
+
+    if period_fs == 0 {
+        return (0, 0);
+    }
+
+    let period = period_fs as u128;
+    let mut shift: u32 = 32;
+    while shift > 0 {
+        let mult = (period * (1u128 << shift) + FS_PER_NS / 2) / FS_PER_NS;
+        if mult <= u64::MAX as u128 {
+            return (mult as u64, shift);
+        }
+        shift -= 1;
+    }
+    let mult = (period + FS_PER_NS / 2) / FS_PER_NS;
+    (mult as u64, 0)
+}
+
+/// Minimal borrow used during discovery, before the full [`HpetClock`] is built.
+struct HpetProbe {
+    base: *mut u64,
+}
+
+impl HpetProbe {
+    unsafe fn read_reg(&self, offset: usize) -> u64 {
+        unsafe { read_volatile(self.base.byte_add(offset) as *const u64) }
+    }
+    unsafe fn write_reg(&self, offset: usize, value: u64) {
+        unsafe { write_volatile(self.base.byte_add(offset) as *mut u64, value) };
+    }
+    unsafe fn read_counter(&self) -> u64 {
+        unsafe { self.read_reg(REG_MAIN_COUNTER) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cs_for_period(period_fs: u64) -> (u64, u32, u64) {
+        let (mult, shift) = compute_mult_shift_period(period_fs);
+        (mult, shift, period_fs)
+    }
+
+    /// Convert `cycles` ticks of a counter with the given period to ns, using the
+    /// same arithmetic as `HpetClock::read_ns`.
+    fn cycles_to_ns(cycles: u64, mult: u64, shift: u32) -> u64 {
+        let raw = (cycles as u128) * (mult as u128);
+        let ns = if shift == 0 {
+            raw
+        } else {
+            (raw + (1u128 << (shift - 1))) >> shift
+        };
+        core::cmp::min(ns, u64::MAX as u128) as u64
+    }
+
+    #[test]
+    fn typical_hpet_period_14mhz() {
+        // QEMU's default HPET runs at ~14.318 MHz (the ATAC clock): period ≈
+        // 69.84 ns ≈ 69_841 fs. 1 tick ≈ 70 ns.
+        let (mult, shift, period_fs) = cs_for_period(69_841);
+        assert!(mult > 0);
+        // 1 tick should be ~70 ns (within rounding).
+        let one_tick = cycles_to_ns(1, mult, shift);
+        assert!((68..=72).contains(&one_tick), "one_tick={}", one_tick);
+        // 1_000_000 ticks ≈ 69.84 ms.
+        let million = cycles_to_ns(1_000_000, mult, shift);
+        let expected = 1_000_000u128 * period_fs / 1_000_000;
+        assert!((million as i128 - expected as i128).abs() <= 2);
+    }
+
+    #[test]
+    fn period_zero_is_rejected() {
+        let (mult, shift) = compute_mult_shift_period(0);
+        assert_eq!(mult, 0);
+        assert_eq!(shift, 0);
+    }
+
+    #[test]
+    fn high_resolution_period_10mhz() {
+        // A 100 ns period (10 MHz) HPET.
+        let (mult, shift) = compute_mult_shift_period(100_000);
+        assert!(mult > 0);
+        // 10 ticks == 1 us == 1000 ns.
+        let ns = cycles_to_ns(10, mult, shift);
+        assert_eq!(ns, 1000);
+    }
+
+    #[test]
+    fn round_trip_rate_matches_period() {
+        // For several realistic periods, the per-tick ns should equal
+        // round(period_fs / 1e6).
+        for &period_fs in &[69_841u64, 100_000, 41_666, 83_333] {
+            let (mult, shift) = compute_mult_shift_period(period_fs);
+            let ns_per_tick = cycles_to_ns(1, mult, shift);
+            let expected = ((period_fs as u128) + 500_000) / 1_000_000;
+            assert!(
+                (ns_per_tick as i128 - expected as i128).abs() <= 1,
+                "period={} ns_per_tick={} expected={}",
+                period_fs,
+                ns_per_tick,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn long_duration_no_overflow() {
+        let (mult, shift, _) = cs_for_period(69_841);
+        // ~1 year of ticks at 14.3 MHz.
+        let one_year_ticks = 14_318_000u64 * 60 * 60 * 24 * 365;
+        let ns = cycles_to_ns(one_year_ticks, mult, shift);
+        let secs = ns / 1_000_000_000;
+        // ~31.5 million seconds in a year.
+        assert!((secs as u128) > 30_000_000 && (secs as u128) < 33_000_000);
+    }
+
+    #[test]
+    fn counter_wrap_handled() {
+        // A wrapping subtraction from an epoch near u64::MAX must produce a small
+        // elapsed ns, not overflow.
+        let (mult, shift, _) = cs_for_period(69_841);
+        let epoch = u64::MAX - 10;
+        let now: u64 = 10; // wrapped past u64::MAX
+        let delta = now.wrapping_sub(epoch);
+        assert_eq!(delta, 21);
+        let ns = cycles_to_ns(delta, mult, shift);
+        let one_tick = cycles_to_ns(1, mult, shift);
+        assert!(ns >= 20 * one_tick && ns <= 21 * one_tick);
+    }
+}

--- a/kernel/twilight_kernel/src/driver/time/hpet.rs
+++ b/kernel/twilight_kernel/src/driver/time/hpet.rs
@@ -115,7 +115,7 @@ pub fn discover() -> Option<HpetClock> {
     // SAFETY: `base` points to the HPET MMIO block, mapped device/uncached by
     // `map_mmio` above. All register accesses are aligned volatile u64 reads/writes
     // at fixed offsets defined by the HPET specification.
-    let (period_fs, epoch) = unsafe {
+    let (period_fs, cfg, epoch) = unsafe {
         let caps = probe.read_reg(REG_CAPABILITIES);
         let period_fs = caps >> 32;
 
@@ -142,6 +142,9 @@ pub fn discover() -> Option<HpetClock> {
         }
 
         // Enable the main counter, preserving unrelated general-configuration bits.
+        // Capture the original config so it can be restored if discovery later
+        // rejects this HPET (e.g. the counter does not advance), leaving device
+        // state as we found it.
         let cfg = probe.read_reg(REG_CONFIG);
         probe.write_reg(REG_CONFIG, cfg | ENABLE_CNF);
 
@@ -150,18 +153,22 @@ pub fn discover() -> Option<HpetClock> {
         // elapsed time relative to its current value rather than resetting it.
         let epoch = probe.read_counter();
 
-        (period_fs, epoch)
+        (period_fs, cfg, epoch)
     };
 
-    // Prove the counter advances before selecting it. Spin briefly via the TSC
-    // (which advances per-cycle even under TCG) and re-read; a non-advancing
-    // counter would freeze guest time.
-    // SAFETY: same MMIO block as above.
-    let tsc0 = super::tsc::read_cycles();
+    // Prove the counter advances before selecting it. A non-advancing counter
+    // would freeze guest time, so reject it explicitly.
+    //
+    // The wait is bounded by an iteration count, NOT by a TSC-frequency-derived
+    // deadline: when `tsc::detect()` returns `None` the published TSC frequency
+    // is 0, and deriving the window from it would collapse to ~one cycle and
+    // reject a perfectly good HPET (#65 review). Each iteration issues a volatile
+    // MMIO read (a device access takes ~1 us on real hardware, far longer than
+    // the ~70 ns HPET period), so a handful of iterations is enough for at least
+    // one counter tick. The cap is generous to cover slow virtualized MMIO.
     let mut advanced = false;
-    // Wait up to ~1 ms of TSC cycles for the counter to tick.
-    let deadline = tsc0.saturating_add(super::tsc::frequency_hz().max(1_000) / 1_000);
-    while super::tsc::read_cycles() < deadline {
+    const ADVANCE_PROBE_ITERS: u32 = 4096;
+    for _ in 0..ADVANCE_PROBE_ITERS {
         // SAFETY: reading the main counter is a fixed volatile MMIO load.
         let now = unsafe { probe.read_counter() };
         if now != epoch {
@@ -171,6 +178,9 @@ pub fn discover() -> Option<HpetClock> {
     }
     if !advanced {
         crate::serial_println!("\x1b[93m[time]\x1b[0m hpet: counter does not advance, rejecting");
+        // Restore the original general-configuration value so we don't leave the
+        // counter enabled after rejecting it.
+        unsafe { probe.write_reg(REG_CONFIG, cfg) };
         return None;
     }
 

--- a/kernel/twilight_kernel/src/driver/time/mod.rs
+++ b/kernel/twilight_kernel/src/driver/time/mod.rs
@@ -1,19 +1,24 @@
 //! Kernel timekeeping: the system timeline, decoupled from interrupt delivery.
 //!
 //! This module owns `CLOCK_MONOTONIC` and `CLOCK_REALTIME`. The monotonic
-//! timeline is read from a continuously advancing hardware clocksource (the
-//! invariant TSC on x86_64), **not** from a count of delivered timer interrupts.
+//! timeline is read from a continuously advancing hardware clocksource — a
+//! validated invariant/paravirtual TSC, or an HPET main counter — **never** from
+//! a count of delivered timer interrupts.
 //!
-//! This is the root-cause fix for #62: under KVM, periodic LAPIC interrupts can
-//! be delayed or coalesced while the vCPU is descheduled, so an interrupt-count
-//! clock permanently loses elapsed time. Reading the TSC instead means host
-//! descheduling no longer erases guest time.
+//! This is the root-cause fix for #65 (and its predecessor #62). Under QEMU TCG,
+//! periodic LAPIC interrupts can be delayed or coalesced while the vCPU is
+//! descheduled, so an interrupt-count clock permanently loses elapsed time. The
+//! previous TCG fallback (`delivered_timer_events * 1ms`) is removed; under TCG
+//! we now read the HPET main counter, which advances at a fixed hardware rate
+//! independent of interrupt delivery.
 //!
-//! Timer interrupts are now pure *clock events*: they drive scheduler ticks and
+//! Timer interrupts are pure *clock events*: they drive scheduler ticks and
 //! deadline expiry via [`handle_timer_event`], but they do not advance the
 //! timeline. The two responsibilities are separated, as Linux and FreeBSD do.
 
 pub mod clocksource;
+pub mod hpet;
+pub mod source;
 pub mod tsc;
 
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -28,14 +33,10 @@ use crate::task::executor::halt;
 
 const NSEC_PER_SEC: u64 = 1_000_000_000;
 
-/// The TSC clocksource, when available. `None` (and `TSC_AVAILABLE = false`)
-/// on QEMU TCG, where the TSC is not a valid clocksource.
-static CLOCKSOURCE: OnceCell<clocksource::ClockSource> = OnceCell::uninit();
-
-/// Whether the TSC clocksource was successfully initialized. When false,
-/// `monotonic_ns()` falls back to the interrupt-count clocksource.
-static TSC_AVAILABLE: core::sync::atomic::AtomicBool =
-    core::sync::atomic::AtomicBool::new(false);
+/// The selected continuously readable clocksource backend. `None` only before
+/// [`init`] has run; if [`init`] cannot select any backend it panics rather than
+/// leaving this unset.
+static CLOCKSOURCE: OnceCell<source::SelectedClocksource> = OnceCell::uninit();
 
 /// Boot-time offset such that `CLOCK_REALTIME = offset + CLOCK_MONOTONIC`.
 /// Established once from the CMOS RTC; the RTC is used only for the epoch, never
@@ -43,36 +44,33 @@ static TSC_AVAILABLE: core::sync::atomic::AtomicBool =
 static REALTIME_OFFSET_NS: AtomicU64 = AtomicU64::new(0);
 static OFFSET_INITED: AtomicU64 = AtomicU64::new(0); // 0 = no, 1 = yes
 
-/// Counter of delivered timer events. Under KVM/bare metal this is diagnostic
-/// only; the TSC is the clocksource. Under QEMU TCG this counter **is** the
-/// clocksource, because TCG delivers every scheduled interrupt (no coalescing)
-/// so one event == one tick period.
+/// Counter of delivered timer events, diagnostic only. The timeline is read from
+/// [`CLOCKSOURCE`]; this counter exists so [`timer_event_count`] can report how
+/// many clock-event IRQs were delivered (used by the regression harness to prove
+/// that delivered-event count can diverge without affecting monotonic time).
 static TIMER_EVENTS: AtomicU64 = AtomicU64::new(0);
 
-/// Nanoseconds per timer event (tick period). The LAPIC timer is calibrated to
-/// 1 kHz, so each event represents 1 ms. Used by the TCG fallback clocksource.
-const NS_PER_TIMER_EVENT: u64 = 1_000_000;
-
-/// Initialize the clocksource. Must run once during boot, before any time read.
+/// Initialize the clocksource. Must run once during boot, before any time read
+/// and before interrupts are enabled.
 ///
-/// On x86_64 this tries the invariant TSC first. Under QEMU TCG (no KVM) the
-/// TSC is not a valid clocksource (it advances at host real time while the
-/// LAPIC/PIT advance at QEMU virtual time, so the two diverge during idle); in
-/// that case we fall back to the interrupt-count clocksource, which is correct
-/// under TCG because TCG delivers every interrupt.
+/// Selection policy (see #65):
+///  1. Validated invariant/paravirtual TSC — correct under KVM `-cpu host` on an
+///     invariant host, or when a paravirtual KVM TSC frequency is advertised.
+///  2. HPET — discovered via ACPI, mapped device/uncached, validated to advance.
+///  3. If neither validates: panic with an explicit message. There is no silent
+///     interrupt-count fallback.
 pub fn init() {
-    match tsc::detect() {
+    // Always try the TSC first. `detect()` calibrates the TSC frequency even when
+    // the TSC is not usable as the clocksource, because `timer::wait` and LAPIC
+    // calibration need a TSC frequency for short busy-waits.
+    let selected = match tsc::detect() {
         Some(tsc) => {
-            let invariant = tsc.is_invariant();
             let freq = tsc.frequency_hz();
             let freq_source = tsc.frequency_source();
-            let usable = tsc.usable_as_clocksource();
-
-            // Always publish the TSC frequency for timer::wait and LAPIC
-            // calibration, even when the TSC is not usable as the clocksource.
             tsc::publish_frequency(freq);
 
-            if usable {
+            if tsc.usable_as_clocksource() {
+                let invariant = tsc.is_invariant();
                 if invariant {
                     crate::serial_println!(
                         "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=true freq={} Hz source={}",
@@ -82,47 +80,65 @@ pub fn init() {
                 } else {
                     crate::serial_println!(
                         "\x1b[93m[time]\x1b[0m clocksource=tsc invariant=false freq={} Hz source={} \
-                         (warning: TSC not advertised invariant; time may drift in deep sleep on bare metal)",
+                         (paravirtual TSC frequency; valid clocksource)",
                         freq,
                         freq_source,
                     );
                 }
-                let _ = CLOCKSOURCE.try_init_once(|| tsc.into_source());
-                TSC_AVAILABLE.store(true, Ordering::Release);
+                source::SelectedClocksource::Tsc(tsc.into_source())
             } else {
-                // TCG: TSC frequency is calibrated for timer::wait/LAPIC, but
-                // the TSC is not the clocksource. Fall back to interrupt count.
-                crate::serial_println!(
-                    "\x1b[93m[time]\x1b[0m clocksource=tick freq={} Hz source={} \
-                     (TCG: TSC calibrated for delays but not usable as clocksource; using interrupt-count)",
-                    freq,
-                    freq_source,
-                );
+                // TSC calibrated but not usable as the clocksource (e.g. QEMU
+                // TCG: no invariant flag, no paravirtual frequency). Try HPET.
+                select_hpet(freq, freq_source)
             }
         }
         None => {
-            // No TSC frequency at all. Fall back to the interrupt-count clocksource.
             crate::serial_println!(
-                "\x1b[93m[time]\x1b[0m clocksource=tick (TSC unavailable; using interrupt-count fallback)"
+                "\x1b[93m[time]\x1b[0m TSC unavailable; selecting HPET clocksource"
             );
+            select_hpet(0, "none")
+        }
+    };
+
+    let _ = CLOCKSOURCE.try_init_once(|| selected);
+}
+
+/// Try to select the HPET backend; panic if it does not validate.
+///
+/// `tsc_freq_hz` / `tsc_freq_source` are passed only for diagnostics.
+fn select_hpet(tsc_freq_hz: u64, tsc_freq_source: &str) -> source::SelectedClocksource {
+    match hpet::discover() {
+        Some(hpet) => {
+            crate::serial_println!(
+                "\x1b[93m[time]\x1b[0m clocksource=hpet (tsc_freq={} Hz source={} not usable; \
+                 HPET selected)",
+                tsc_freq_hz,
+                tsc_freq_source,
+            );
+            source::SelectedClocksource::Hpet(hpet)
+        }
+        None => {
+            // No continuous backend validated. Per #65, fail explicitly rather
+            // than silently falling back to an interrupt-count clocksource.
+            crate::serial_println!(
+                "\x1b[91m[time]\x1b[0m FATAL: no continuous clocksource validated \
+                 (TSC unusable, HPET unavailable); refusing to boot with interrupt-count fallback"
+            );
+            panic!("no continuous clocksource validated (TSC unusable, HPET unavailable)");
         }
     }
 }
 
 /// Continuously advancing monotonic nanoseconds since boot.
 ///
-/// Under KVM/bare metal this reads the TSC clocksource and does not depend on
-/// interrupt delivery. Under QEMU TCG it falls back to counting delivered timer
-/// events (correct there because TCG does not coalesce interrupts).
+/// Reads the selected hardware backend (TSC or HPET) directly. Does not depend on
+/// interrupt delivery: late or coalesced timer IRQs do not affect this value.
 #[inline]
 pub fn monotonic_ns() -> u64 {
-    if TSC_AVAILABLE.load(Ordering::Acquire) {
-        if let Some(cs) = CLOCKSOURCE.get() {
-            return cs.elapsed_ns(tsc::read_cycles());
-        }
+    match CLOCKSOURCE.get() {
+        Some(cs) => cs.read_ns(),
+        None => 0,
     }
-    // TCG fallback: each delivered timer event is one tick period.
-    TIMER_EVENTS.load(Ordering::Relaxed) * NS_PER_TIMER_EVENT
 }
 
 /// Wall-clock nanoseconds since the Unix epoch (`CLOCK_REALTIME`).
@@ -160,7 +176,9 @@ pub fn handle_timer_event() {
     crate::sys::proc::on_timer_tick();
 }
 
-/// Diagnostic: number of timer events delivered since boot.
+/// Diagnostic: number of timer events delivered since boot. Used by the
+/// regression harness to prove delivered-event count can diverge from monotonic
+/// time without losing elapsed time.
 pub fn timer_event_count() -> u64 {
     TIMER_EVENTS.load(Ordering::Relaxed)
 }
@@ -174,32 +192,30 @@ pub fn timer_event_count() -> u64 {
 /// Two strategies are used, selected by duration:
 ///
 /// * **Short sleeps** (below [`SHORT_SLEEP_THRESHOLD_NS`]) busy-wait on the TSC
-///   via [`crate::driver::timer::wait`]. This is necessary because under QEMU TCG
-///   the fallback clocksource ([`monotonic_ns`]) has 1 ms granularity (one tick
-///   per delivered LAPIC interrupt), so an `hlt`-based sleep of less than 1 ms
-///   rounds up to the next tick — up to a ~100× overshoot for a 10 µs sleep. The
-///   TSC advances per executed cycle even under TCG, so a TSC busy-wait is precise
-///   for short intervals and never stalls (it spins rather than halting, so it is
-///   immune to TCG virtual-clock-during-hlt behavior). The CPU cost is bounded by
-///   the short duration. This mirrors how Linux (`udelay`/`ndelay`) and FreeBSD
+///   via [`crate::driver::timer::wait`]. This counts TSC cycles, which advance
+///   per executed instruction even under QEMU TCG, so it is a precise *delay*
+///   regardless of which clocksource backs `CLOCK_MONOTONIC`. (The TSC is not
+///   used as the system clocksource under TCG because its wall rate diverges
+///   from virtual time during `hlt`, but for a short busy-wait that rate error is
+///   negligible.) This mirrors how Linux (`udelay`/`ndelay`) and FreeBSD
 ///   (`DELAY`) realize sub-tick delays.
 ///
 /// * **Long sleeps** (at/above the threshold) use a `sti; hlt` loop keyed on
-///   [`monotonic_ns`], which is efficient (the CPU halts while waiting) and for
-///   which 1 ms tick quantization is negligible.
+///   [`monotonic_ns`], which is efficient (the CPU halts while waiting) and
+///   precise because `monotonic_ns` reads the continuous clocksource (TSC or
+///   HPET), not the tick count.
 ///
-/// Under KVM/bare metal the TSC is the clocksource, so both paths are precise;
-/// the threshold only selects between busy-waiting and halting. A deadline-
-/// ordered timer wheel that blocks sleeping tasks across tick boundaries (so a
-/// long sleep is not woken once per tick) remains a tracked follow-up in #62.
+/// A deadline-ordered timer wheel that blocks sleeping tasks across tick
+/// boundaries (so a long sleep is not woken once per tick) remains a tracked
+/// follow-up in #62.
 pub fn sleep_ns(nanoseconds: u64) {
     if nanoseconds == 0 {
         return;
     }
 
     // Below the tick quantization, busy-wait on the TSC for precision. The
-    // threshold is a few tick periods: any sleep that would suffer large
-    // relative error from 1 ms rounding takes the precise busy-wait path.
+    // threshold is a few tick periods: any sleep that would suffer large relative
+    // error from 1 ms rounding takes the precise busy-wait path.
     if nanoseconds < SHORT_SLEEP_THRESHOLD_NS {
         crate::driver::timer::wait(nanoseconds);
         return;
@@ -215,10 +231,12 @@ pub fn sleep_ns(nanoseconds: u64) {
 }
 
 /// Durations below this are realized as a TSC busy-wait rather than an `hlt`
-/// loop. Chosen as a small multiple of [`NS_PER_TIMER_EVENT`] (the 1 ms tick
-/// period under the TCG fallback clocksource) so that any sleep whose accuracy
-/// would be dominated by tick quantization takes the precise busy-wait path.
-const SHORT_SLEEP_THRESHOLD_NS: u64 = NS_PER_TIMER_EVENT * 2;
+/// loop. A small multiple of the 1 ms tick period so that any sleep whose
+/// accuracy would be dominated by tick quantization takes the precise busy-wait
+/// path. Under an HPET clocksource the long-sleep path is already precise (HPET
+/// resolution is typically ~70 ns), so the threshold only selects between
+/// busy-waiting and halting for short durations.
+const SHORT_SLEEP_THRESHOLD_NS: u64 = 2_000_000;
 
 /// Validate and execute a relative `nanosleep`/`clock_nanosleep` request.
 pub fn sleep_timespec(req: &Timespec) -> Result<(), i64> {

--- a/kernel/twilight_kernel/src/driver/time/source.rs
+++ b/kernel/twilight_kernel/src/driver/time/source.rs
@@ -1,0 +1,40 @@
+//! Selected clocksource backend policy.
+//!
+//! The monotonic timeline is read from exactly one continuously advancing
+//! hardware backend, chosen once at boot by [`super::init`]. This module owns the
+//! selected backend and the dispatch from `monotonic_ns()` to a hardware read.
+//!
+//! Selection order (see #65):
+//!  1. validated invariant/paravirtual TSC (KVM `-cpu host` on an invariant
+//!     host, or a paravirtual KVM TSC frequency);
+//!  2. HPET (under QEMU TCG or when TSC validation fails);
+//!  3. explicit initialization failure — there is no silent interrupt-count
+//!     fallback.
+
+use super::hpet::HpetClock;
+use super::clocksource::ClockSource;
+
+/// The continuously readable backend backing `CLOCK_MONOTONIC`.
+///
+/// Stored in a `OnceCell` so the hot read path is a single `get()` + match.
+pub enum SelectedClocksource {
+    /// Validated invariant/paravirtual TSC.
+    Tsc(ClockSource),
+    /// HPET main counter.
+    Hpet(HpetClock),
+}
+
+impl SelectedClocksource {
+    /// Read elapsed monotonic nanoseconds from the selected backend.
+    ///
+    /// Lock-free and allocation-free for both backends. The TSC path reads the
+    /// TSC and applies the calibrated mult/shift; the HPET path reads the main
+    /// counter MMIO register.
+    #[inline]
+    pub fn read_ns(&self) -> u64 {
+        match self {
+            SelectedClocksource::Tsc(cs) => cs.elapsed_ns(super::tsc::read_cycles()),
+            SelectedClocksource::Hpet(hpet) => hpet.read_ns(),
+        }
+    }
+}

--- a/kernel/twilight_kernel/src/driver/time/tsc.rs
+++ b/kernel/twilight_kernel/src/driver/time/tsc.rs
@@ -7,10 +7,12 @@
 //! the correct virtualized clocksource: it advances with real elapsed time even
 //! when the vCPU is descheduled and periodic LAPIC interrupts are coalesced.
 //!
-//! This is the root-cause fix for #62: elapsed time is read from the TSC, not
-//! from a count of delivered timer interrupts.
+//! The TSC is selected as the clocksource only when validated as stable: either
+//! CPUID advertises an invariant TSC, or a paravirtual KVM TSC frequency is
+//! present. Calibration alone is not a stability guarantee. When the TSC is not
+//! usable (e.g. under QEMU TCG), the HPET backend is used instead (#65).
 
-use raw_cpuid::{CpuId, Hypervisor};
+use raw_cpuid::CpuId;
 
 use super::clocksource::{compute_mult_shift, ClockSource};
 
@@ -25,10 +27,11 @@ pub struct TscClock {
     freq_source: &'static str,
     /// Whether CPUID advertised an invariant TSC.
     invariant: bool,
-    /// Whether the TSC is usable as the system clocksource. False under QEMU
-    /// TCG, where the TSC advances at host real time while LAPIC/PIT advance at
-    /// QEMU virtual time. The frequency is still calibrated (for `timer::wait`
-    /// and LAPIC calibration) even when this is false.
+    /// Whether the TSC is usable as the system clocksource. True only when the
+    /// TSC is validated as stable (invariant flag, or a paravirtual KVM TSC
+    /// frequency). Calibration alone is not a stability guarantee. False under
+    /// QEMU TCG, where the TSC advances at host real time while LAPIC/PIT advance
+    /// at QEMU virtual time; the caller falls back to HPET.
     usable_as_clocksource: bool,
 }
 
@@ -49,8 +52,11 @@ impl TscClock {
         self.invariant
     }
 
-    /// Whether the TSC should be used as the system clocksource. False under
-    /// TCG; the caller falls back to the interrupt-count clocksource.
+    /// Whether the TSC should be used as the system clocksource. True only when
+    /// the TSC is validated as a stable, continuously advancing counter: either
+    /// CPUID advertises an invariant TSC, or a paravirtual KVM TSC frequency is
+    /// present. Calibration alone is **not** a stability guarantee. The caller
+    /// falls back to HPET when this is false.
     pub fn usable_as_clocksource(&self) -> bool {
         self.usable_as_clocksource
     }
@@ -129,42 +135,25 @@ fn has_rdtscp() -> bool {
 
 /// Detect and calibrate a TSC clocksource.
 ///
-/// The TSC is used whenever a frequency can be determined. The CPUID "invariant
-/// TSC" flag is a *quality* guarantee (the TSC does not stop in deep C-states),
-/// not a usability requirement: under software emulation (TCG) there are no real
-/// C-states, so the TSC advances correctly even when the flag is absent. We
-/// therefore do not refuse to boot when the flag is unset; we only log a warning
-/// so the operator knows the clock may drift on real hardware that lacks it.
+/// The TSC frequency is always resolved when possible, because `timer::wait`
+/// and LAPIC calibration need a TSC frequency for short busy-waits even when
+/// the TSC is not usable as the system clocksource.
 ///
 /// Frequency is resolved, in order of preference, by:
-///  1. CPUID leaf 0x15 (`TscInfo::tsc_frequency()`) — exact, no measurement.
-///  2. CPUID leaf 0x16 processor base frequency (MHz → Hz).
-///  3. PIT-calibrated measurement against a known wall interval (cycle count,
+///  1. Hypervisor paravirtual TSC frequency (KVM leaf 0x40000010, exact kHz).
+///     Also a stability signal: KVM guarantees TSC continuity across deschedule.
+///  2. CPUID leaf 0x15 (`TscInfo::tsc_frequency()`) — exact, no measurement.
+///  3. CPUID leaf 0x16 processor base frequency (MHz → Hz).
+///  4. PIT-calibrated measurement against a known wall interval (cycle count,
 ///     **not** interrupt count).
 ///
-/// Returns `None` only if no frequency could be determined. On the reported KVM
-/// `-cpu host` configuration the TSC is invariant and CPUID.15h is available, so
-/// path 1 is taken.
-///
-/// Returns `None` only if no frequency could be determined. Even under QEMU
-/// TCG (where the TSC is not usable as the system clocksource) the frequency is
-/// still calibrated and returned, because `timer::wait` and LAPIC calibration
-/// need a TSC frequency for short busy-waits. The caller checks
-/// `usable_as_clocksource()` to decide whether to use the TSC as the clocksource
-/// or fall back to the interrupt-count clocksource.
+/// Returns `None` if no frequency can be determined. Otherwise the caller checks
+/// [`TscClock::usable_as_clocksource`] to decide whether to use the TSC as the
+/// clocksource or fall back to HPET (#65). The TSC is usable only when validated
+/// as stable (invariant flag or paravirtual frequency); calibration alone is not
+/// a stability guarantee.
 pub fn detect() -> Option<TscClock> {
     let cpuid = CpuId::new();
-
-    // Under QEMU TCG (no KVM), the TSC advances at host real time while the
-    // LAPIC/PIT advance at QEMU virtual time. During `hlt` (idle), the virtual
-    // clock pauses but the host TSC keeps going, so the TSC-based clock would
-    // run fast. TCG delivers every interrupt (no coalescing), so the interrupt
-    // count is a valid clocksource there. We still calibrate the TSC frequency
-    // (for timer::wait and LAPIC calibration) but mark it unusable as clocksource.
-    let is_tcg = cpuid
-        .get_hypervisor_info()
-        .map(|h| matches!(h.identify(), Hypervisor::QEMU))
-        .unwrap_or(false);
 
     // Probe rdtscp once and cache it for the hot read path.
     let rdtscp = cpuid
@@ -185,23 +174,28 @@ pub fn detect() -> Option<TscClock> {
     //  2. CPUID leaf 0x15 (TscInfo::tsc_frequency()) — exact, no measurement.
     //  3. CPUID leaf 0x16 processor base frequency (MHz → Hz).
     //  4. PIT-calibrated measurement (fallback; see calibrate_with_pit).
-    let (freq_hz, freq_source) = cpuid
+    //
+    // A paravirtual KVM TSC frequency (source 1) is also a *stability* signal:
+    // KVM guarantees the TSC advances with real elapsed time even when the vCPU
+    // is descheduled, so it is a valid clocksource regardless of the invariant
+    // flag. We track whether we used it.
+    let (freq_hz, freq_source, paravirtual) = cpuid
         .get_hypervisor_info()
         .and_then(|h| h.tsc_frequency())
         .filter(|&khz| khz > 0)
-        .map(|khz| (khz as u64 * 1_000, "kvm.0x40000010"))
+        .map(|khz| (khz as u64 * 1_000, "kvm.0x40000010", true))
         .or_else(|| {
             cpuid
                 .get_tsc_info()
                 .and_then(|t| t.tsc_frequency())
-                .map(|f| (f, "cpuid.0x15"))
+                .map(|f| (f, "cpuid.0x15", false))
         })
         .or_else(|| {
             cpuid
                 .get_processor_frequency_info()
-                .map(|p| (p.processor_base_frequency() as u64 * 1_000_000, "cpuid.0x16"))
+                .map(|p| (p.processor_base_frequency() as u64 * 1_000_000, "cpuid.0x16", false))
         })
-        .unwrap_or_else(|| (calibrate_with_pit(), "pit-calibration"));
+        .unwrap_or_else(|| (calibrate_with_pit(), "pit-calibration", false));
 
     if freq_hz < MIN_FREQ_HZ {
         return None;
@@ -211,11 +205,21 @@ pub fn detect() -> Option<TscClock> {
     let epoch = read_cycles();
     let source = ClockSource::new(epoch, mult, shift, freq_hz);
 
+    // The TSC is a valid clocksource only when validated as stable: either the
+    // CPUID invariant-TSC flag is set, or a paravirtual KVM TSC frequency was
+    // provided (KVM guarantees TSC continuity across deschedule). Calibration
+    // alone (PIT/0x16) is NOT a stability guarantee — under QEMU TCG the TSC
+    // advances at host real time while LAPIC/PIT advance at QEMU virtual time,
+    // so a calibrated-only TSC diverges during `hlt`. The hypervisor vendor is
+    // explicitly not used as a clock-quality test (#65): a stable/invariant or
+    // paravirtual TSC is accepted on any hypervisor that advertises one.
+    let usable_as_clocksource = invariant || paravirtual;
+
     Some(TscClock {
         source,
         freq_source,
         invariant,
-        usable_as_clocksource: !is_tcg,
+        usable_as_clocksource,
     })
 }
 

--- a/kernel/twilight_kernel/src/main.rs
+++ b/kernel/twilight_kernel/src/main.rs
@@ -241,12 +241,16 @@ pub fn init(
 
     arch::x86_64::syscall::init();
 
-    x86_64::instructions::interrupts::enable();
+    // Discover and cache ACPI tables. The HPET clocksource (selected below when
+    // the TSC is not validated) is discovered through these tables, so ACPI must
+    // be initialized before the time subsystem. This also wires power control.
+    sys::acpi::init();
 
     // Initialize the clocksource before anything that reads time or calibrates
-    // against it. The TSC clocksource is detected from CPUID (no IRQs needed)
-    // and publishes the TSC frequency used by `timer::wait` and LAPIC
-    // calibration below. This must precede `timer::init` and `lapic::init`.
+    // against it, and before interrupts are enabled. Selection policy (#65):
+    // validated invariant/paravirtual TSC, else HPET, else explicit failure.
+    // The TSC frequency is published here for `timer::wait` and LAPIC calibration
+    // below. This must precede `timer::init` and `lapic::init`.
     driver::time::init();
 
     driver::timer::init();
@@ -256,7 +260,8 @@ pub fn init(
     driver::apic::lapic::init();
 
     // Establish the realtime epoch from the CMOS RTC. The RTC defines the
-    // wall-clock origin; elapsed time thereafter comes from the TSC clocksource.
+    // wall-clock origin; elapsed time thereafter comes from the selected
+    // clocksource (TSC or HPET).
     driver::time::init_realtime_offset_from_cmos();
 
     // Mask PIT (IRQ0) to prevent double ticks
@@ -266,6 +271,9 @@ pub fn init(
         // Preserve all dynamically unmasked IRQs (e.g. UHCI IRQ10) and only mask IRQ0.
         pics.write_masks(masks[0] | 0x01, masks[1]);
     }
+
+    // Complete PIT/LAPIC setup before BSP interrupts are globally enabled (#65).
+    x86_64::instructions::interrupts::enable();
 
     kernel_utils::dhcp::main();
 }

--- a/kernel/twilight_kernel/src/sys/acpi.rs
+++ b/kernel/twilight_kernel/src/sys/acpi.rs
@@ -1,15 +1,33 @@
-use crate::sys::memory::phys_to_virt;
+//! ACPI table discovery and power control.
+//!
+//! [`init`] performs ACPI discovery once at boot and caches the resulting
+//! [`AcpiTables`] in [`ACPI_TABLES`] so that drivers (e.g. the HPET clocksource)
+//! can derive information from the tables without rescanning. The cached tables
+//! live for the lifetime of the kernel: `AcpiTables` borrows the RSDP/XSDT
+//! memory, which is permanent firmware-owned RAM and is never reclaimed.
+
 use crate::{println, sys};
 use acpi::{AcpiHandler, AcpiTables, PhysicalMapping};
 use alloc::boxed::Box;
 use aml::{AmlContext, AmlName, AmlValue, DebugVerbosity, Handler};
 use core::ptr::NonNull;
+use spin::Mutex;
 use x86_64::PhysAddr;
 use x86_64::instructions::port::Port;
 
 static mut PM1A_CNT_BLK: u32 = 0;
 static mut SLP_TYPA: u16 = 0;
 static SLP_LEN: u16 = 0;
+
+/// The system's ACPI tables, discovered once during [`init`] and cached for the
+/// lifetime of the kernel.
+///
+/// `AcpiTables` is `Send` (its `PhysicalMapping` is `Send` when the handler is)
+/// but not `Sync` (the mapping holds a `NonNull`), so it is stored behind a
+/// [`Mutex`], which is `Sync` whenever `T: Send`. Drivers borrow it through
+/// [`with_tables`] rather than rescanning for the RSDP themselves. The borrowed
+/// firmware memory is permanent, so the `'static` lifetime is sound.
+static ACPI_TABLES: Mutex<Option<AcpiTables<KernelAcpiHandler>>> = Mutex::new(None);
 
 #[derive(Clone)]
 pub struct KernelAcpiHandler;
@@ -24,8 +42,12 @@ impl AcpiHandler for KernelAcpiHandler {
         physical_address: usize,
         size: usize,
     ) -> PhysicalMapping<Self, T> {
-        let phys_addr = PhysAddr::new(physical_address as u64);
-        let virt_addr = phys_to_virt(phys_addr);
+        // Firmware regions (BIOS ROM, EBDA, ACPI tables in reserved memory) are
+        // not part of the usable-RAM HHDM map, so ensure they are mapped before
+        // dereferencing. `ensure_physical_mapped` is a no-op for already-mapped
+        // ranges.
+        let virt_addr = sys::memory::ensure_physical_mapped(physical_address as u64, size)
+            .expect("ACPI: failed to map physical region");
         let ptr = NonNull::new(virt_addr.as_mut_ptr()).unwrap();
         unsafe { PhysicalMapping::new(physical_address, ptr, size, size, Self) }
     }
@@ -33,51 +55,74 @@ impl AcpiHandler for KernelAcpiHandler {
     fn unmap_physical_region<T>(_region: &PhysicalMapping<Self, T>) {}
 }
 
+/// Run a closure with the cached ACPI tables, if [`init`] has completed
+/// successfully.
+///
+/// Drivers call this (e.g. to build `HpetInfo`) instead of rescanning for the
+/// RSDP themselves. Returns `None` if ACPI discovery failed or has not run.
+pub fn with_tables<R>(f: impl FnOnce(&AcpiTables<KernelAcpiHandler>) -> R) -> Option<R> {
+    let guard = ACPI_TABLES.lock();
+    guard.as_ref().map(f)
+}
+
+/// Discover and cache the ACPI tables, then set up power control (FADT/DSDT/S5).
+///
+/// Called once during boot, before any driver that consumes ACPI-derived
+/// information (notably the HPET clocksource). After this returns, [`with_tables`]
+/// is available.
 pub fn init() {
     let res = unsafe { AcpiTables::search_for_rsdp_bios(KernelAcpiHandler) };
     match res {
         Ok(acpi) => {
-            if let Ok(fadt) = acpi.find_table::<acpi::fadt::Fadt>() {
-                if let Ok(block) = fadt.pm1a_control_block() {
-                    unsafe {
-                        PM1A_CNT_BLK = block.address as u32;
-                    }
-                }
-            }
-            if let Ok(dsdt) = acpi.dsdt() {
-                let phys_addr = PhysAddr::new(dsdt.address as u64);
-                let virt_addr = sys::memory::phys_to_virt(phys_addr);
-                let ptr = virt_addr.as_ptr();
-                let table = unsafe { core::slice::from_raw_parts(ptr, dsdt.length as usize) };
-                let handler = Box::new(KernelAmlHandler);
-                let mut aml = AmlContext::new(handler, DebugVerbosity::None);
-                if aml.parse_table(table).is_ok() {
-                    let name = AmlName::from_str("\\_S5").unwrap();
-                    let res = aml.namespace.get_by_path(&name);
-                    if let Ok(AmlValue::Package(s5)) = res {
-                        if let AmlValue::Integer(value) = s5[0] {
-                            unsafe {
-                                SLP_TYPA = value as u16;
-                            }
-                        }
-                    }
-                } else {
-                    println!("ACPI: Could not parse AML in DSDT");
-                    // FIXME: AML parsing works on QEMU and Bochs but not
-                    // on VirtualBox at the moment, so we use the following
-                    // hardcoded value:
-                    unsafe {
-                        SLP_TYPA = (5 & 7) << 10;
-                    }
-                }
-            } else {
-                println!("ACPI: Could not find DSDT in BIOS");
-            }
+            setup_power_control(&acpi);
+            *ACPI_TABLES.lock() = Some(acpi);
         }
         Err(_e) => {
-            println!("ACPI: Could not find RDSP in BIOS");
+            println!("ACPI: Could not find RSDP in BIOS");
         }
-    };
+    }
+}
+
+/// Extract FADT/DSDT/S5 sleep-state information for [`shutdown`].
+fn setup_power_control(acpi: &AcpiTables<KernelAcpiHandler>) {
+    if let Ok(fadt) = acpi.find_table::<acpi::fadt::Fadt>() {
+        if let Ok(block) = fadt.pm1a_control_block() {
+            unsafe {
+                PM1A_CNT_BLK = block.address as u32;
+            }
+        }
+    }
+    if let Ok(dsdt) = acpi.dsdt() {
+        // The DSDT lives in firmware/reserved memory that may not be part of the
+        // usable-RAM HHDM map, so ensure it is mapped before reading.
+        let virt_addr = sys::memory::ensure_physical_mapped(dsdt.address as u64, dsdt.length as usize)
+            .unwrap_or_else(|_| sys::memory::phys_to_virt(PhysAddr::new(dsdt.address as u64)));
+        let ptr = virt_addr.as_ptr();
+        let table = unsafe { core::slice::from_raw_parts(ptr, dsdt.length as usize) };
+        let handler = Box::new(KernelAmlHandler);
+        let mut aml = AmlContext::new(handler, DebugVerbosity::None);
+        if aml.parse_table(table).is_ok() {
+            let name = AmlName::from_str("\\_S5").unwrap();
+            let res = aml.namespace.get_by_path(&name);
+            if let Ok(AmlValue::Package(s5)) = res {
+                if let AmlValue::Integer(value) = s5[0] {
+                    unsafe {
+                        SLP_TYPA = value as u16;
+                    }
+                }
+            }
+        } else {
+            println!("ACPI: Could not parse AML in DSDT");
+            // FIXME: AML parsing works on QEMU and Bochs but not
+            // on VirtualBox at the moment, so we use the following
+            // hardcoded value:
+            unsafe {
+                SLP_TYPA = (5 & 7) << 10;
+            }
+        }
+    } else {
+        println!("ACPI: Could not find DSDT in BIOS");
+    }
 }
 
 pub fn shutdown() {

--- a/kernel/twilight_kernel/src/sys/acpi.rs
+++ b/kernel/twilight_kernel/src/sys/acpi.rs
@@ -94,9 +94,21 @@ fn setup_power_control(acpi: &AcpiTables<KernelAcpiHandler>) {
     }
     if let Ok(dsdt) = acpi.dsdt() {
         // The DSDT lives in firmware/reserved memory that may not be part of the
-        // usable-RAM HHDM map, so ensure it is mapped before reading.
-        let virt_addr = sys::memory::ensure_physical_mapped(dsdt.address as u64, dsdt.length as usize)
-            .unwrap_or_else(|_| sys::memory::phys_to_virt(PhysAddr::new(dsdt.address as u64)));
+        // usable-RAM HHDM map, so ensure it is mapped before reading. If mapping
+        // fails, skip parsing rather than dereferencing an unmapped address — keep
+        // the hardcoded `_S5` fallback so shutdown still works.
+        let virt_addr =
+            match sys::memory::ensure_physical_mapped(dsdt.address as u64, dsdt.length as usize)
+            {
+                Ok(v) => v,
+                Err(()) => {
+                    println!("ACPI: could not map DSDT; using hardcoded S5 fallback");
+                    unsafe {
+                        SLP_TYPA = (5 & 7) << 10;
+                    }
+                    return;
+                }
+            };
         let ptr = virt_addr.as_ptr();
         let table = unsafe { core::slice::from_raw_parts(ptr, dsdt.length as usize) };
         let handler = Box::new(KernelAmlHandler);

--- a/kernel/twilight_kernel/src/sys/memory/mod.rs
+++ b/kernel/twilight_kernel/src/sys/memory/mod.rs
@@ -394,6 +394,12 @@ pub fn map_mmio(phys_addr: u64, size: usize) -> Result<(), ()> {
     let end_frame: PhysFrame = PhysFrame::containing_address(PhysAddr::new(phys_addr + size));
     let frames = PhysFrame::range_inclusive(start_frame, end_frame);
 
+    // Device MMIO must be uncached. The HHDM pre-maps all physical memory as
+    // write-back, so for any MMIO region that already has a mapping we must
+    // *update* the page-table flags to device/uncached rather than silently
+    // leaving the cached mapping in place (which would corrupt reads through
+    // the CPU cache). `map_to` fails on an existing mapping; on that failure we
+    // fall back to `update_flags`.
     let flags = PageTableFlags::PRESENT
         | PageTableFlags::WRITABLE
         | PageTableFlags::NO_CACHE
@@ -406,16 +412,76 @@ pub fn map_mmio(phys_addr: u64, size: usize) -> Result<(), ()> {
             let page = Page::containing_address(virt);
 
             unsafe {
-                if let Ok(mapping) = mapper().map_to(page, frame, flags, frame_allocator) {
-                    mapping.flush();
-                } else {
-                    // If it failed, it might be already mapped.
-                    // We try to update flags just in case, or ignore.
+                match mapper().map_to(page, frame, flags, frame_allocator) {
+                    Ok(mapping) => mapping.flush(),
+                    Err(_) => {
+                        // Already mapped (typically the HHDM identity of this
+                        // physical frame). Force device/uncached flags so MMIO
+                        // accesses bypass the cache.
+                        match mapper().update_flags(page, flags) {
+                            Ok(mapping) => mapping.flush(),
+                            Err(_) => return Err(()),
+                        }
+                    }
                 }
             }
         }
-    });
+        Ok(())
+    })?;
     Ok(())
+}
+
+/// Ensure a physical address range is mapped into the HHDM as normal cached
+/// memory and return its kernel-virtual address.
+///
+/// The HHDM maps usable RAM, but firmware regions (BIOS ROM, EBDA, ACPI tables
+/// in reserved memory) are not part of the usable-RAM map and may be unmapped.
+/// ACPI table discovery scans these regions, so this helper maps any missing
+/// pages as write-back before the handler dereferences them. Already-mapped
+/// ranges are left untouched.
+pub fn ensure_physical_mapped(phys_addr: u64, size: usize) -> Result<VirtAddr, ()> {
+    use x86_64::structures::paging::{
+        mapper::TranslateResult, PageTableFlags, Translate,
+    };
+
+    let virt = phys_to_virt(PhysAddr::new(phys_addr));
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+
+    // Iterate every page the range touches. The HHDM maps usable RAM, but
+    // firmware regions (BIOS ROM, EBDA, ACPI tables in reserved memory) may be
+    // only partially mapped — a table spanning a page boundary can have its
+    // first page mapped (usable RAM) and its second page unmapped (reserved),
+    // so checking only the start address is not enough. Map each unmapped page;
+    // leave already-mapped pages untouched.
+    let last = phys_addr.saturating_add(size.saturating_sub(1) as u64);
+    let start_frame: PhysFrame = PhysFrame::containing_address(PhysAddr::new(phys_addr));
+    let end_frame: PhysFrame = PhysFrame::containing_address(PhysAddr::new(last));
+    let frames = PhysFrame::range_inclusive(start_frame, end_frame);
+
+    with_frame_allocator(|frame_allocator| {
+        for frame in frames {
+            let page = Page::containing_address(phys_to_virt(frame.start_address()));
+            // Skip pages that are already mapped (avoids disturbing existing
+            // usable-RAM mappings and wasting allocator frames).
+            if !matches!(
+                mapper().translate(page.start_address()),
+                TranslateResult::NotMapped | TranslateResult::InvalidFrameAddress(_)
+            ) {
+                continue;
+            }
+            unsafe {
+                match mapper().map_to(page, frame, flags, frame_allocator) {
+                    Ok(mapping) => mapping.flush(),
+                    Err(_) => {
+                        // A concurrent mapper may have mapped it; ignore.
+                    }
+                }
+            }
+        }
+        Ok(())
+    })?;
+
+    Ok(virt)
 }
 
 pub fn memory_size() -> usize {

--- a/kernel/twilight_kernel/src/sys/memory/mod.rs
+++ b/kernel/twilight_kernel/src/sys/memory/mod.rs
@@ -387,14 +387,17 @@ pub fn phys_addr(ptr: *const u8) -> u64 {
 }
 
 pub fn map_mmio(phys_addr: u64, size: usize) -> Result<(), ()> {
-    use x86_64::structures::paging::PageTableFlags;
+    use x86_64::structures::paging::{
+        mapper::{FlagUpdateError, MapToError},
+        PageTableFlags,
+    };
 
     let size = size.saturating_sub(1) as u64;
     let start_frame: PhysFrame = PhysFrame::containing_address(PhysAddr::new(phys_addr));
     let end_frame: PhysFrame = PhysFrame::containing_address(PhysAddr::new(phys_addr + size));
     let frames = PhysFrame::range_inclusive(start_frame, end_frame);
 
-    // Device MMIO must be uncached. The HHDM pre-maps all physical memory as
+    // Device MMIO must be uncached. The HHDM pre-maps usable physical memory as
     // write-back, so for any MMIO region that already has a mapping we must
     // *update* the page-table flags to device/uncached rather than silently
     // leaving the cached mapping in place (which would corrupt reads through
@@ -414,15 +417,31 @@ pub fn map_mmio(phys_addr: u64, size: usize) -> Result<(), ()> {
             unsafe {
                 match mapper().map_to(page, frame, flags, frame_allocator) {
                     Ok(mapping) => mapping.flush(),
-                    Err(_) => {
-                        // Already mapped (typically the HHDM identity of this
-                        // physical frame). Force device/uncached flags so MMIO
-                        // accesses bypass the cache.
+                    // Already mapped (typically the HHDM identity of this physical
+                    // frame). Force device/uncached flags so MMIO accesses bypass
+                    // the cache.
+                    Err(MapToError::PageAlreadyMapped(_)) => {
                         match mapper().update_flags(page, flags) {
                             Ok(mapping) => mapping.flush(),
+                            Err(FlagUpdateError::ParentEntryHugePage) => {
+                                // The HHDM mapped this region with a 2 MiB / 1 GiB
+                                // huge page. We cannot reflag a 4 KiB slice of a huge
+                                // page without splitting it, which is not done here.
+                                // Fail explicitly so the caller does not silently
+                                // use a cached MMIO mapping (which would corrupt
+                                // reads). Per #65 the caller then fails loudly.
+                                crate::serial_println!(
+                                    "\x1b[91m[mem]\x1b[0m map_mmio: {:#x} lies under a \
+                                     huge-page HHDM mapping; cannot set uncached",
+                                    phys
+                                );
+                                return Err(());
+                            }
                             Err(_) => return Err(()),
                         }
                     }
+                    // Out of frames, or a parent huge-page entry we can't split.
+                    Err(_) => return Err(()),
                 }
             }
         }
@@ -441,7 +460,8 @@ pub fn map_mmio(phys_addr: u64, size: usize) -> Result<(), ()> {
 /// ranges are left untouched.
 pub fn ensure_physical_mapped(phys_addr: u64, size: usize) -> Result<VirtAddr, ()> {
     use x86_64::structures::paging::{
-        mapper::TranslateResult, PageTableFlags, Translate,
+        mapper::{MapToError, TranslateResult},
+        PageTableFlags, Translate,
     };
 
     let virt = phys_to_virt(PhysAddr::new(phys_addr));
@@ -472,9 +492,13 @@ pub fn ensure_physical_mapped(phys_addr: u64, size: usize) -> Result<VirtAddr, (
             unsafe {
                 match mapper().map_to(page, frame, flags, frame_allocator) {
                     Ok(mapping) => mapping.flush(),
-                    Err(_) => {
-                        // A concurrent mapper may have mapped it; ignore.
-                    }
+                    // A concurrent mapper may have mapped this page between our
+                    // translate check and the map_to call; that is benign.
+                    Err(MapToError::PageAlreadyMapped(_)) => {}
+                    // Genuine failures (out of frames, or a parent huge-page entry
+                    // we can't split here): propagate so the caller does not
+                    // dereference an unmapped address.
+                    Err(_) => return Err(()),
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #65.

The QEMU TCG clocksource fallback derived `CLOCK_MONOTONIC` from `delivered_timer_events * 1ms`, permanently losing elapsed time whenever a periodic LAPIC interrupt was coalesced or delayed while the vCPU was descheduled. This PR fixes the **root cause**: monotonic time is now read from a continuously advancing hardware counter, never from interrupt count.

### Selection policy (`driver/time/mod.rs`)
1. **Validated invariant/paravirtual TSC** — invariant flag (CPUID 0x80000007 EDX[8]) or paravirtual KVM frequency (leaf 0x40000010). Calibration alone is **not** a stability guarantee.
2. **HPET main counter** — discovered via ACPI, mapped device/uncached, validated to advance.
3. **Explicit panic** — no silent interrupt-count fallback.

The hypervisor vendor is no longer used as a clock-quality test (`usable_as_clocksource = !is_tcg` removed).

### HPET backend (`driver/time/hpet.rs`)
One aligned volatile u64 read of the main counter at MMIO +0x0F0, wrapping-sub from a boot epoch, fixed-point mult/shift computed from the femtosecond counter period (no integer-Hz rounding). Lock-free, allocation-free. `discover()` validates 64-bit counter, plausible period, and counter advance before selecting.

### ACPI caching (`sys/acpi.rs`)
ACPI tables are cached once at boot in a `Mutex<Option<AcpiTables>>` (Send but not Sync) and exposed via `with_tables()` so the HPET driver does not rescan. `acpi::init()` runs before interrupts are enabled and before `time::init()`.

### Memory bug fixes
- `ensure_physical_mapped()` now iterates every page in a firmware region; the fast-path that only checked the start address page-faulted on tables spanning a page boundary (FADT at 0x1ffe0040 len 8617).
- `map_mmio()` now falls back to `update_flags(NO_CACHE)` when `map_to` hits an existing HHDM write-back mapping, so device MMIO bypasses the cache.

## Verification
- TCG core2duo boots with `clocksource=hpet` and reaches userspace.
- Time regression harness passes: `failures=0`, `early=0 backward=0` across rel/abs/read/poll/load modes; a 100ms sleep measures ~100.7ms of real time (previously it would lose time when IRQs were coalesced).
- Failure path verified: when no continuous backend validates, the kernel panics with an explicit message rather than silently falling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable monotonic timing using validated TSC hardware with HPET fallback.
  * Improved support for ACPI-discovered hardware timers and memory-mapped devices.
  * Added clearer clocksource selection and initialization behavior.

* **Bug Fixes**
  * Improved timing accuracy across counter wraparound and long durations.
  * Prevented non-monotonic time readings.
  * Improved handling of already-mapped hardware memory regions.

* **Documentation**
  * Added comprehensive documentation covering clocksource selection, timing guarantees, testing, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->