### PR TITLE
feat(time): one-shot LAPIC clockevents replacing 1kHz periodic tick

### DIFF
--- a/kernel/twilight_kernel/src/driver/apic/lapic.rs
+++ b/kernel/twilight_kernel/src/driver/apic/lapic.rs
@@ -1,4 +1,14 @@
+//! Local APIC driver.
+//!
+//! The timer is programmed in **one-shot mode** as a clockevent: each event is
+//! armed for a specific nanosecond delta and fires once. This replaces the old
+//! fixed 1 kHz periodic tick (#68). A periodic fallback is retained behind
+//! [`FORCE_PERIODIC_FALLBACK`] (and auto-selected when calibration rejects) so
+//! the kernel can still boot on a CPU model that miscalibrates; the fallback is a
+//! delivery mechanism only and never serves as a clocksource.
+
 use crate::sys::memory::phys_mem_offset;
+use conquer_once::spin::OnceCell;
 use core::ptr::{read_volatile, write_volatile};
 
 // Standard Local APIC base address
@@ -17,10 +27,33 @@ const TCCR_REG: u64 = 0x390; // Timer Current Count
 const TDCR_REG: u64 = 0x3E0; // Timer Divide Config
 const LVT_TIMER_REG: u64 = 0x320; // LVT Timer
 
-// Timer Modes
-#[allow(dead_code)]
+// Timer Modes (LVT timer bits).
 const TIMER_ONE_SHOT: u32 = 0x00;
 const TIMER_PERIODIC: u32 = 0x20000;
+
+/// Timer interrupt vector used by both one-shot and periodic modes.
+const TIMER_VECTOR: u32 = 0xFD;
+
+/// Divide-by-16 configuration value for TDCR.
+const DIVIDE_BY_16: u32 = 0x3;
+
+/// Force the periodic 1 kHz fallback regardless of calibration. Debug switch:
+/// leave false unless diagnosing a one-shot regression.
+const FORCE_PERIODIC_FALLBACK: bool = false;
+
+/// Duration of the calibration busy-wait, in nanoseconds (10 ms). Measured
+/// against the selected continuous clocksource, not an assumed interval.
+const CALIB_NS: u64 = 10_000_000;
+
+/// Plausible LAPIC input-frequency bounds. The bus/crystal frequency that feeds
+/// the LAPIC timer is at most a few GHz; reject anything outside this range as
+/// a calibration failure and fall back to periodic.
+const FREQ_MIN_HZ: u64 = 1_000; // 1 kHz
+const FREQ_MAX_HZ: u64 = 10_000_000_000; // 10 GHz
+
+/// Minimum safe initial count. Programming a count of 0 or 1 can race the LAPIC
+/// and fail to fire; use a small floor.
+const MIN_COUNT_TICKS: u32 = 8;
 
 pub unsafe fn write_reg(offset: u64, value: u32) {
     let base = phys_mem_offset() + LAPIC_BASE;
@@ -54,51 +87,316 @@ pub fn init() {
         // Enable LAPIC (set bit 8 of SVR, and map vector 0xFF to spurious interrupts)
         write_reg(SVR_REG, 0x100 | 0xFF);
 
-        // Mask timer interrupt for now
-        write_reg(LVT_TIMER_REG, 0x10000);
+        // Mask timer interrupt until calibration/arming decides the mode.
+        write_reg(LVT_TIMER_REG, MASKED);
 
-        // Set Timer Divide Configuration to Divide by 16 (value: 0x3)
-        // 0x3 means divide by 16 for standard APIC
-        write_reg(TDCR_REG, 0x3);
+        // Divide by 16 for both calibration and runtime.
+        write_reg(TDCR_REG, DIVIDE_BY_16);
 
-        // Init timer calibration
-        calibrate_timer();
+        calibrate_and_program();
     }
 }
 
-fn calibrate_timer() {
-    // Calibrate the LAPIC timer interval against the TSC clocksource, not the
-    // interrupt-count clock. The old code called `pit::sleep_ns(10ms)`, which
-    // counted delivered timer interrupts; under KVM those can be coalesced,
-    // producing an interval that is too long and a clock that runs slow for the
-    // whole boot (#62). Busy-waiting on the TSC measures real elapsed time.
+const MASKED: u32 = 0x10000;
 
-    unsafe {
-        // One shot mode, large value
-        write_reg(TICR_REG, 0xFFFFFFFF);
+/// Calibrated one-shot clockevent parameters. `None` only before [`init`].
+static LAPIC_CE: OnceCell<LapicClockevent> = OnceCell::uninit();
+
+#[derive(Clone, Copy)]
+struct LapicClockevent {
+    /// LAPIC timer ticks per second, derived from the continuous clocksource.
+    ticks_per_sec: u64,
+    /// Minimum delta expressible as a safe initial count, in nanoseconds.
+    min_delta_ns: u64,
+    /// Mode selected at init: one-shot, or periodic fallback.
+    mode: ClockeventMode,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ClockeventMode {
+    OneShot,
+    PeriodicFallback,
+}
+
+impl LapicClockevent {
+    fn max_delta_ns(&self) -> u64 {
+        // Nanoseconds corresponding to the full 32-bit count range.
+        ticks_to_ns(u32::MAX, self.ticks_per_sec)
+    }
+}
+
+/// Calibrate the LAPIC timer against the selected continuous clocksource and
+/// select one-shot or periodic-fallback mode.
+///
+/// Root-cause fix (#68): the previous code calibrated against a TSC busy-wait
+/// and *assumed* the wait lasted exactly 10 ms. Under TCG the runtime clocksource
+/// may be HPET (a different timebase than the TSC), so calibrating LAPIC ticks
+/// against the TSC while deadlines are measured in HPET time is a domain
+/// mismatch. We instead measure the actual elapsed clocksource interval and
+/// compute `ticks_per_sec = elapsed_ticks * 1e9 / (clock_end - clock_start)`.
+fn calibrate_and_program() {
+    if FORCE_PERIODIC_FALLBACK {
+        program_periodic_fallback("force_periodic_fallback");
+        return;
     }
 
-    // Wait 10 ms of real time using the TSC.
-    crate::driver::timer::wait(10_000_000);
-
-    let ticks_in_10ms = unsafe {
-        let current = read_reg(TCCR_REG);
-        0xFFFFFFFF - current
+    let Some(ce) = calibrate_oneshot() else {
+        program_periodic_fallback("calibration_rejected");
+        return;
     };
 
-    let ticks_per_ms = ticks_in_10ms / 10;
+    let _ = LAPIC_CE.try_init_once(|| ce);
+    crate::serial_println!(
+        "\x1b[93m[time]\x1b[0m clockevent=oneshot ticks/sec={} min_delta_ns={} max_delta_ns={}",
+        ce.ticks_per_sec,
+        ce.min_delta_ns,
+        ce.max_delta_ns(),
+    );
+}
 
-    // Target: 1000Hz -> 1ms per tick
-    let interval = ticks_per_ms; // 1 ms
-
+/// Run the one-shot calibration and return the parameters if plausible.
+fn calibrate_oneshot() -> Option<LapicClockevent> {
     unsafe {
-        // Periodic mode, vector 0xFD (as planned), unmasked
-        write_reg(LVT_TIMER_REG, TIMER_PERIODIC | 0xFD);
+        // One-shot mode, large initial count. The counter counts down from
+        // TICR; elapsed ticks = (TICR - TCCR) over the measurement window.
+        write_reg(LVT_TIMER_REG, TIMER_ONE_SHOT | TIMER_VECTOR);
+        write_reg(TDCR_REG, DIVIDE_BY_16);
+        write_reg(TICR_REG, u32::MAX);
+    }
 
-        // Set divider again to be sure
-        write_reg(TDCR_REG, 0x3);
+    // Measure the actual elapsed clocksource interval. Read the selected
+    // backend (TSC or HPET) — the same timebase the deadline queue uses — so a
+    // domain mismatch cannot skew the conversion.
+    let start = crate::driver::time::monotonic_ns();
+    busy_wait_ns(CALIB_NS);
+    let end = crate::driver::time::monotonic_ns();
 
-        // Start timer
-        write_reg(TICR_REG, interval);
+    let elapsed_ticks = u32::MAX.wrapping_sub(unsafe { read_reg(TCCR_REG) });
+    let elapsed_ns = end.checked_sub(start)?;
+
+    // ticks/sec = elapsed_ticks * 1e9 / elapsed_ns  (wide multiply-before-divide)
+    if elapsed_ns == 0 {
+        return None;
+    }
+    let ticks_per_sec = (elapsed_ticks as u128)
+        .checked_mul(1_000_000_000)
+        .and_then(|p| p.checked_div(elapsed_ns as u128))
+        .and_then(|v| u64::try_from(v).ok())?;
+    let ticks_per_sec: u64 = ticks_per_sec;
+
+    if !(FREQ_MIN_HZ..=FREQ_MAX_HZ).contains(&ticks_per_sec) || elapsed_ticks == 0 {
+        return None;
+    }
+
+    let min_delta_ns = ticks_to_ns(MIN_COUNT_TICKS, ticks_per_sec).max(1);
+    Some(LapicClockevent {
+        ticks_per_sec,
+        min_delta_ns,
+        mode: ClockeventMode::OneShot,
+    })
+}
+
+/// Program the periodic 1 kHz fallback. Used when calibration fails or the debug
+/// switch forces it. The periodic tick drives clock events; one-shot APIs
+/// become no-ops.
+fn program_periodic_fallback(reason: &str) {
+    // Derive a 1 ms interval from the clocksource-calibrated tick rate if we
+    // can; otherwise fall back to a conservative PIT-derived estimate. Either
+    // way this is a delivery mechanism only, never a clocksource.
+    let ticks_per_ms = estimate_ticks_per_ms();
+    unsafe {
+        write_reg(LVT_TIMER_REG, TIMER_PERIODIC | TIMER_VECTOR);
+        write_reg(TDCR_REG, DIVIDE_BY_16);
+        write_reg(TICR_REG, ticks_per_ms.max(1));
+    }
+    let _ = LAPIC_CE.try_init_once(|| LapicClockevent {
+        ticks_per_sec: (ticks_per_ms as u64).saturating_mul(1000),
+        min_delta_ns: 1_000_000,
+        mode: ClockeventMode::PeriodicFallback,
+    });
+    crate::serial_println!(
+        "\x1b[93m[time]\x1b[0m clockevent=periodic-fallback reason={} ticks/ms={}",
+        reason,
+        ticks_per_ms,
+    );
+}
+
+/// Best-effort 1 ms tick count for the periodic fallback. Reuses the one-shot
+/// calibration machinery but does not depend on its plausibility checks.
+fn estimate_ticks_per_ms() -> u32 {
+    unsafe {
+        write_reg(LVT_TIMER_REG, TIMER_ONE_SHOT | TIMER_VECTOR);
+        write_reg(TDCR_REG, DIVIDE_BY_16);
+        write_reg(TICR_REG, u32::MAX);
+    }
+    let start = crate::driver::time::monotonic_ns();
+    busy_wait_ns(1_000_000);
+    let end = crate::driver::time::monotonic_ns();
+    let elapsed_ticks = u32::MAX.wrapping_sub(unsafe { read_reg(TCCR_REG) });
+    let elapsed_ns = end.saturating_sub(start).max(1);
+    // ticks per millisecond, ceiling.
+    let per_sec = (elapsed_ticks as u128)
+        .saturating_mul(1_000_000_000)
+        .checked_div(elapsed_ns as u128)
+        .unwrap_or(0);
+    (per_sec / 1000).try_into().unwrap_or(1).max(1)
+}
+
+/// Busy-wait approximately `nanoseconds` using the selected clocksource.
+///
+/// Unlike the TSC-domain `timer::wait`, this reads `monotonic_ns()` so it stays
+/// in the same timebase the deadline queue uses — correct under TCG where the
+/// clocksource may be HPET.
+fn busy_wait_ns(nanoseconds: u64) {
+    if nanoseconds == 0 {
+        return;
+    }
+    let start = crate::driver::time::monotonic_ns();
+    while crate::driver::time::monotonic_ns().wrapping_sub(start) < nanoseconds {
+        core::hint::spin_loop();
+    }
+}
+
+// --- ns <-> ticks conversion ------------------------------------------------
+
+/// Convert nanoseconds to LAPIC ticks with ceiling, clamped to `u32` range.
+fn ns_to_ticks(delta_ns: u64, ticks_per_sec: u64) -> u32 {
+    if ticks_per_sec == 0 || delta_ns == 0 {
+        return MIN_COUNT_TICKS;
+    }
+    let ticks = ((delta_ns as u128)
+        .saturating_mul(ticks_per_sec as u128)
+        .saturating_add(999_999_999))
+        / 1_000_000_000;
+    if ticks > u32::MAX as u128 {
+        u32::MAX
+    } else if ticks < MIN_COUNT_TICKS as u128 {
+        MIN_COUNT_TICKS
+    } else {
+        ticks as u32
+    }
+}
+
+/// Convert LAPIC ticks to nanoseconds (floor).
+fn ticks_to_ns(ticks: u32, ticks_per_sec: u64) -> u64 {
+    if ticks_per_sec == 0 {
+        return 0;
+    }
+    ((ticks as u128).saturating_mul(1_000_000_000) / ticks_per_sec as u128) as u64
+}
+
+// --- public clockevent API --------------------------------------------------
+
+/// Program a one-shot timer event `delta_ns` nanoseconds in the future.
+///
+/// `delta_ns` is clamped to `[min_delta_ns, max_delta_ns]`; an already-due or
+/// sub-minimum delta is clamped up to `min_delta_ns` so the LAPIC reliably fires.
+/// No-op in periodic-fallback mode (the periodic tick drives events).
+pub fn program_oneshot_ns(delta_ns: u64) {
+    let Some(ce) = LAPIC_CE.get() else {
+        return;
+    };
+    if ce.mode != ClockeventMode::OneShot {
+        return;
+    }
+    let delta = delta_ns.clamp(ce.min_delta_ns, ce.max_delta_ns());
+    let count = ns_to_ticks(delta, ce.ticks_per_sec);
+    unsafe {
+        write_reg(LVT_TIMER_REG, TIMER_ONE_SHOT | TIMER_VECTOR);
+        write_reg(TDCR_REG, DIVIDE_BY_16);
+        write_reg(TICR_REG, count);
+    }
+}
+
+/// Disarm the timer. Masks the LVT timer entry. No-op in periodic-fallback mode.
+pub fn cancel_timer() {
+    let Some(ce) = LAPIC_CE.get() else {
+        return;
+    };
+    if ce.mode != ClockeventMode::OneShot {
+        return;
+    }
+    unsafe {
+        write_reg(LVT_TIMER_REG, MASKED);
+    }
+}
+
+/// Minimum safe delta in nanoseconds. Sub-minimum deltas are clamped up to this.
+pub fn min_delta_ns() -> u64 {
+    LAPIC_CE.get().map_or(1, |ce| ce.min_delta_ns)
+}
+
+/// Maximum expressible delta in nanoseconds (full 32-bit count range).
+pub fn max_delta_ns() -> u64 {
+    LAPIC_CE.get().map_or(u64::MAX, |ce| ce.max_delta_ns())
+}
+
+/// Selected clockevent mode, for diagnostics.
+pub fn mode() -> &'static str {
+    match LAPIC_CE.get() {
+        Some(ce) if ce.mode == ClockeventMode::OneShot => "oneshot",
+        Some(_) => "periodic-fallback",
+        None => "uninitialized",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ns_to_ticks_ceils_sub_tick_to_minimum() {
+        // 1 ns at 1 GHz is ~1 tick; below MIN_COUNT_TICKS floors to minimum.
+        let tps = 1_000_000_000;
+        assert_eq!(ns_to_ticks(0, tps), MIN_COUNT_TICKS);
+        assert_eq!(ns_to_ticks(1, tps), MIN_COUNT_TICKS);
+        // Exactly one tick's worth of ns still respects the minimum floor.
+        let one_tick_ns = ticks_to_ns(1, tps);
+        assert_eq!(ns_to_ticks(one_tick_ns, tps), MIN_COUNT_TICKS);
+    }
+
+    #[test]
+    fn ns_to_ticks_ceils_positive_deltas() {
+        let tps = 1_000_000_000; // 1 tick per ns
+        // 999_999_999 ns -> just under 1e9 ticks -> ceil to 1e9 ticks.
+        assert_eq!(ns_to_ticks(999_999_999, tps), 1_000_000_000);
+        // 1_000_000_001 ns -> ceil to 1_000_000_001 ticks.
+        assert_eq!(ns_to_ticks(1_000_000_001, tps), 1_000_000_001);
+    }
+
+    #[test]
+    fn ns_to_ticks_clamps_to_u32_max() {
+        let tps = 1_000_000_000;
+        // A huge delta saturates to u32::MAX rather than wrapping.
+        assert_eq!(ns_to_ticks(u64::MAX, tps), u32::MAX);
+    }
+
+    #[test]
+    fn ns_to_ticks_zero_frequency_is_safe() {
+        assert_eq!(ns_to_ticks(1_000_000, 0), MIN_COUNT_TICKS);
+    }
+
+    #[test]
+    fn ticks_to_ns_round_trips_within_floor() {
+        let tps = 2_000_000_000; // 2 ticks/ns
+        // 1_000_000_000 ns -> 2_000_000_000 ticks -> back to 1_000_000_000 ns.
+        let ticks = ns_to_ticks(1_000_000_000, tps);
+        assert_eq!(ticks_to_ns(ticks, tps), 1_000_000_000);
+    }
+
+    #[test]
+    fn ticks_to_ns_zero_frequency_is_safe() {
+        assert_eq!(ticks_to_ns(123, 0), 0);
+    }
+
+    #[test]
+    fn clamp_uses_min_delta_for_due_deadline() {
+        // Simulates an already-due deadline: clamp(min, max) of 0 yields min.
+        let min = 1_000u64;
+        let max = 1_000_000_000u64;
+        assert_eq!(0u64.clamp(min, max), min);
+        assert_eq!(5u64.clamp(min, max), min);
+        assert_eq!(max.clamp(min, max), max);
+        assert_eq!((max + 1).clamp(min, max), max);
     }
 }

--- a/kernel/twilight_kernel/src/driver/apic/lapic.rs
+++ b/kernel/twilight_kernel/src/driver/apic/lapic.rs
@@ -189,6 +189,12 @@ fn calibrate_oneshot() -> Option<LapicClockevent> {
     }
 
     let min_delta_ns = ticks_to_ns(MIN_COUNT_TICKS, ticks_per_sec).max(1);
+    // Mask the LVT timer so the calibration counter (still counting down from
+    // u32::MAX) cannot fire a spurious interrupt between here and the first
+    // real rearm. The first clockevent::rearm() re-enables and programs it.
+    unsafe {
+        write_reg(LVT_TIMER_REG, MASKED);
+    }
     Some(LapicClockevent {
         ticks_per_sec,
         min_delta_ns,
@@ -247,12 +253,22 @@ fn estimate_ticks_per_ms() -> u32 {
 /// Unlike the TSC-domain `timer::wait`, this reads `monotonic_ns()` so it stays
 /// in the same timebase the deadline queue uses — correct under TCG where the
 /// clocksource may be HPET.
+///
+/// Bounded: if the clocksource stalls (e.g. a broken HPET MMIO read under a
+/// misconfigured QEMU model), give up after `CALIB_NS * 4` rather than hang the
+/// boot forever. The caller rejects the resulting zero/implausible elapsed
+/// interval and falls back to the periodic timer.
 fn busy_wait_ns(nanoseconds: u64) {
     if nanoseconds == 0 {
         return;
     }
     let start = crate::driver::time::monotonic_ns();
+    // Cap at 4x the requested interval so a stalled clock cannot spin forever.
+    let escape = nanoseconds.saturating_mul(4);
     while crate::driver::time::monotonic_ns().wrapping_sub(start) < nanoseconds {
+        if crate::driver::time::monotonic_ns().wrapping_sub(start) >= escape {
+            break;
+        }
         core::hint::spin_loop();
     }
 }
@@ -357,11 +373,19 @@ mod tests {
 
     #[test]
     fn ns_to_ticks_ceils_positive_deltas() {
+        // At 1 tick/ns every integer nanosecond converts exactly — no ceiling
+        // is involved, so this checks exact conversion at a 1 GHz rate.
         let tps = 1_000_000_000; // 1 tick per ns
-        // 999_999_999 ns -> just under 1e9 ticks -> ceil to 1e9 ticks.
-        assert_eq!(ns_to_ticks(999_999_999, tps), 1_000_000_000);
-        // 1_000_000_001 ns -> ceil to 1_000_000_001 ticks.
+        assert_eq!(ns_to_ticks(999_999_999, tps), 999_999_999);
         assert_eq!(ns_to_ticks(1_000_000_001, tps), 1_000_000_001);
+
+        // A frequency that does not divide evenly into 1e9 exercises the ceil:
+        // 1.5 GHz means 1.5 ticks/ns, so 7 ns = 10.5 ticks -> ceil to 11. Pick
+        // deltas above MIN_COUNT_TICKS so the minimum-count floor does not clamp
+        // the result and obscure the rounding.
+        let tps_frac = 1_500_000_000;
+        assert_eq!(ns_to_ticks(7, tps_frac), 11); // 10.5 -> ceil 11
+        assert_eq!(ns_to_ticks(6, tps_frac), 9); // 9.0 -> exact 9
     }
 
     #[test]

--- a/kernel/twilight_kernel/src/driver/time/clockevent.rs
+++ b/kernel/twilight_kernel/src/driver/time/clockevent.rs
@@ -43,21 +43,37 @@ pub fn init() {
 /// or disarm if both are absent.
 ///
 /// Called from hard-IRQ context (after expiry, before EOI) and from task context
-/// after a deadline is inserted or cancelled. Callers must have IRQs disabled
-/// (hard-IRQ, or holding a `lock_irq` guard).
+/// after a deadline is inserted or cancelled. Task-context callers may run with
+/// interrupts enabled, so the sample/store/program sequence is wrapped in
+/// [`without_interrupts`]: this prevents a hard-IRQ [`rearm`] from interleaving
+/// with this call and clobbering a value sampled before the interrupt. With
+/// interrupts disabled on the (only) running CPU, the armed-deadline state is
+/// exclusively owned for the duration of the call, so a plain store is safe.
 pub fn rearm(now_ns: u64) {
-    let target = earliest_deadline();
-    match target {
-        None => {
-            ARMED_DEADLINE.store(ARMED_NONE, Ordering::Release);
-            lapic::cancel_timer();
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        let target = earliest_deadline();
+        match target {
+            None => {
+                ARMED_DEADLINE.store(ARMED_NONE, Ordering::Release);
+                lapic::cancel_timer();
+            }
+            Some(abs) => {
+                ARMED_DEADLINE.store(abs, Ordering::Release);
+                let delta = abs.saturating_sub(now_ns).max(lapic::min_delta_ns());
+                lapic::program_oneshot_ns(delta);
+            }
         }
-        Some(abs) => {
-            ARMED_DEADLINE.store(abs, Ordering::Release);
-            let delta = abs.saturating_sub(now_ns).max(lapic::min_delta_ns());
-            lapic::program_oneshot_ns(delta);
-        }
-    }
+    });
+}
+
+/// Decide whether `new_abs` should replace the currently armed deadline `cur`.
+///
+/// A real deadline always replaces [`ARMED_NONE`] (the "no event" sentinel), and
+/// a strictly earlier deadline replaces a later one. Equal or later deadlines do
+/// not replace — the armed event already fires no later than `new_abs`.
+#[inline]
+fn should_replace(cur: u64, new_abs: u64) -> bool {
+    new_abs < cur
 }
 
 /// Atomically reprogram the LAPIC if `new_abs` is earlier than the currently
@@ -71,7 +87,7 @@ pub fn rearm(now_ns: u64) {
 pub fn rearm_if_earlier(now_ns: u64, new_abs: u64) {
     loop {
         let cur = ARMED_DEADLINE.load(Ordering::Acquire);
-        if new_abs >= cur {
+        if !should_replace(cur, new_abs) {
             return; // Already armed no later than the new deadline.
         }
         if ARMED_DEADLINE
@@ -109,14 +125,6 @@ fn earliest_deadline() -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::sync::atomic::AtomicU64;
-
-    /// Reset the armed-deadline static to a known value for an isolated test.
-    /// Tests that touch `ARMED_DEADLINE` must not run concurrently with each
-    /// other (the host test harness runs them sequentially).
-    fn reset_armed(to: u64) {
-        ARMED_DEADLINE.store(to, Ordering::SeqCst);
-    }
 
     #[test]
     fn armed_none_sentinel_is_never_a_real_deadline() {
@@ -142,36 +150,28 @@ mod tests {
         assert_eq!(earliest(None, None), None);
     }
 
-    /// `rearm_if_earlier` must not overwrite an earlier armed deadline with a
-    /// later one. We simulate the CAS logic directly against a local atomic so
-    /// the test does not depend on LAPIC hardware.
+    /// `should_replace` must not overwrite an earlier armed deadline with a later
+    /// one, and must replace when the new deadline is strictly earlier. Tested
+    /// against the pure predicate directly so the test does not depend on LAPIC
+    /// hardware.
     #[test]
-    fn rearm_if_earlier_does_not_overwrite_earlier_with_later() {
-        let armed = AtomicU64::new(1000); // already armed at 1000
-        let new_abs = 2000u64; // later — must NOT replace
-        let cur = armed.load(Ordering::Acquire);
-        assert!(new_abs >= cur);
-        // The guard in rearm_if_earlier returns without CAS in this case.
-        assert_eq!(armed.load(Ordering::Acquire), 1000);
+    fn should_replace_rejects_later_or_equal() {
+        // A later deadline must not replace an earlier armed one.
+        assert!(!should_replace(1000, 2000));
+        // An equal deadline must not replace (no point reprogramming).
+        assert!(!should_replace(1000, 1000));
     }
 
     #[test]
-    fn rearm_if_earlier_replaces_when_new_is_strictly_earlier() {
-        let armed = AtomicU64::new(2000);
-        let new_abs = 1000u64;
-        let cur = armed.load(Ordering::Acquire);
-        assert!(new_abs < cur);
-        let _ = armed
-            .compare_exchange(cur, new_abs, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok();
-        assert_eq!(armed.load(Ordering::Acquire), 1000);
+    fn should_replace_accepts_strictly_earlier() {
+        assert!(should_replace(2000, 1000));
     }
 
     #[test]
-    fn rearm_if_earlier_treats_none_as_earliest() {
-        reset_armed(ARMED_NONE);
-        let cur = ARMED_DEADLINE.load(Ordering::Acquire);
-        let new_abs = 5_000_000u64;
-        assert!(new_abs < cur, "any real deadline is earlier than ARMED_NONE");
+    fn should_replace_treats_none_as_earliest() {
+        // Any real deadline is earlier than ARMED_NONE, so it replaces.
+        assert!(should_replace(ARMED_NONE, 5_000_000));
+        // ARMED_NONE itself does not replace a real deadline.
+        assert!(!should_replace(5_000_000, ARMED_NONE));
     }
 }

--- a/kernel/twilight_kernel/src/driver/time/clockevent.rs
+++ b/kernel/twilight_kernel/src/driver/time/clockevent.rs
@@ -1,0 +1,177 @@
+//! One-shot clockevent policy: program the LAPIC for the earliest of the next
+//! software deadline or the scheduler quantum deadline (#68).
+//!
+//! This is the policy layer above the LAPIC *mechanism* ([`crate::driver::apic::lapic`])
+//! and below the *consumers* (the deadline queue in [`crate::sys::timer`] and the
+//! scheduler quantum in [`crate::sys::preempt`]). It owns the armed-event state:
+//! the absolute monotonic deadline currently programmed into the hardware.
+//!
+//! ## Invariants
+//!
+//! - The clockevent never advances `CLOCK_MONOTONIC`; it only reads it.
+//! - An earlier insertion cannot be delayed behind an older programmed deadline.
+//!   [`rearm_if_earlier`] atomically compare/replaces the armed deadline and
+//!   reprograms the LAPIC when a new deadline is earlier.
+//! - Idle with no deadlines disarms the timer, so no periodic interrupts fire.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use crate::driver::apic::lapic;
+
+/// Sentinel stored in [`ARMED_DEADLINE`] when no event is armed. `u64::MAX` is
+/// never a real monotonic deadline (it would block for ~584 years).
+const ARMED_NONE: u64 = u64::MAX;
+
+/// The absolute monotonic deadline currently programmed into the LAPIC, or
+/// [`ARMED_NONE`] when disarmed.
+///
+/// Touched under IRQ-disabled sections (hard-IRQ rearm, or `lock_irq` critical
+/// sections in the blocking paths). The CAS in [`rearm_if_earlier`] makes an
+/// earlier insertion win even if a concurrent rearm is choosing its next event.
+static ARMED_DEADLINE: AtomicU64 = AtomicU64::new(ARMED_NONE);
+
+/// Initialize the clockevent subsystem. Called after the LAPIC is calibrated.
+pub fn init() {
+    ARMED_DEADLINE.store(ARMED_NONE, Ordering::Relaxed);
+    // Arm the first event for the current earliest deadline (if any). At boot
+    // there are no sleepers and the quantum is not yet armed, so this typically
+    // disarms; the first context switch arms the quantum.
+    rearm(crate::driver::time::monotonic_ns());
+}
+
+/// Program the LAPIC for `min(earliest_software_deadline, quantum_deadline)`,
+/// or disarm if both are absent.
+///
+/// Called from hard-IRQ context (after expiry, before EOI) and from task context
+/// after a deadline is inserted or cancelled. Callers must have IRQs disabled
+/// (hard-IRQ, or holding a `lock_irq` guard).
+pub fn rearm(now_ns: u64) {
+    let target = earliest_deadline();
+    match target {
+        None => {
+            ARMED_DEADLINE.store(ARMED_NONE, Ordering::Release);
+            lapic::cancel_timer();
+        }
+        Some(abs) => {
+            ARMED_DEADLINE.store(abs, Ordering::Release);
+            let delta = abs.saturating_sub(now_ns).max(lapic::min_delta_ns());
+            lapic::program_oneshot_ns(delta);
+        }
+    }
+}
+
+/// Atomically reprogram the LAPIC if `new_abs` is earlier than the currently
+/// armed deadline. This is the **final earliest-deadline recheck** called inside
+/// the queue `lock_irq` critical section before releasing it, so an insertion
+/// racing with IRQ rearm cannot be lost: if the new deadline is earlier, it wins
+/// the CAS and the hardware is reprogrammed immediately.
+///
+/// `now_ns` is the current monotonic time, used to convert the absolute
+/// deadline to a delta. Callers must hold IRQs disabled.
+pub fn rearm_if_earlier(now_ns: u64, new_abs: u64) {
+    loop {
+        let cur = ARMED_DEADLINE.load(Ordering::Acquire);
+        if new_abs >= cur {
+            return; // Already armed no later than the new deadline.
+        }
+        if ARMED_DEADLINE
+            .compare_exchange(cur, new_abs, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            let delta = new_abs.saturating_sub(now_ns).max(lapic::min_delta_ns());
+            lapic::program_oneshot_ns(delta);
+            return;
+        }
+        // Lost the race to a concurrent writer; retry.
+    }
+}
+
+/// Disarm unconditionally and clear the armed state. Used when the running task
+/// enters idle with no peer to preempt for and no sleepers.
+pub fn disarm() {
+    ARMED_DEADLINE.store(ARMED_NONE, Ordering::Release);
+    lapic::cancel_timer();
+}
+
+/// The earliest of the next software deadline and the scheduler quantum
+/// deadline, or `None` if neither exists.
+fn earliest_deadline() -> Option<u64> {
+    let sw = crate::sys::timer::next_deadline_ns();
+    let q = crate::sys::preempt::quantum_deadline_ns();
+    match (sw, q) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::AtomicU64;
+
+    /// Reset the armed-deadline static to a known value for an isolated test.
+    /// Tests that touch `ARMED_DEADLINE` must not run concurrently with each
+    /// other (the host test harness runs them sequentially).
+    fn reset_armed(to: u64) {
+        ARMED_DEADLINE.store(to, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn armed_none_sentinel_is_never_a_real_deadline() {
+        // u64::MAX would block ~584 years; safe as "no event".
+        assert_eq!(ARMED_NONE, u64::MAX);
+    }
+
+    #[test]
+    fn earliest_of_two_picks_the_smaller() {
+        // Mirrors earliest_deadline's min logic without touching globals.
+        fn earliest(sw: Option<u64>, q: Option<u64>) -> Option<u64> {
+            match (sw, q) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            }
+        }
+        assert_eq!(earliest(Some(100), Some(200)), Some(100));
+        assert_eq!(earliest(Some(200), Some(100)), Some(100));
+        assert_eq!(earliest(Some(100), None), Some(100));
+        assert_eq!(earliest(None, Some(100)), Some(100));
+        assert_eq!(earliest(None, None), None);
+    }
+
+    /// `rearm_if_earlier` must not overwrite an earlier armed deadline with a
+    /// later one. We simulate the CAS logic directly against a local atomic so
+    /// the test does not depend on LAPIC hardware.
+    #[test]
+    fn rearm_if_earlier_does_not_overwrite_earlier_with_later() {
+        let armed = AtomicU64::new(1000); // already armed at 1000
+        let new_abs = 2000u64; // later — must NOT replace
+        let cur = armed.load(Ordering::Acquire);
+        assert!(new_abs >= cur);
+        // The guard in rearm_if_earlier returns without CAS in this case.
+        assert_eq!(armed.load(Ordering::Acquire), 1000);
+    }
+
+    #[test]
+    fn rearm_if_earlier_replaces_when_new_is_strictly_earlier() {
+        let armed = AtomicU64::new(2000);
+        let new_abs = 1000u64;
+        let cur = armed.load(Ordering::Acquire);
+        assert!(new_abs < cur);
+        let _ = armed
+            .compare_exchange(cur, new_abs, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+        assert_eq!(armed.load(Ordering::Acquire), 1000);
+    }
+
+    #[test]
+    fn rearm_if_earlier_treats_none_as_earliest() {
+        reset_armed(ARMED_NONE);
+        let cur = ARMED_DEADLINE.load(Ordering::Acquire);
+        let new_abs = 5_000_000u64;
+        assert!(new_abs < cur, "any real deadline is earlier than ARMED_NONE");
+    }
+}

--- a/kernel/twilight_kernel/src/driver/time/mod.rs
+++ b/kernel/twilight_kernel/src/driver/time/mod.rs
@@ -16,6 +16,7 @@
 //! deadline expiry via [`handle_timer_event`], but they do not advance the
 //! timeline. The two responsibilities are separated, as Linux and FreeBSD do.
 
+pub mod clockevent;
 pub mod clocksource;
 pub mod hpet;
 pub mod source;
@@ -190,18 +191,28 @@ pub fn ensure_realtime_offset_inited() {
 
 /// Clock-event handler invoked by the timer ISR.
 ///
-/// This advances scheduler state and expires deadlines; it does **not** advance
-/// the timeline. The timeline is read from the clocksource on demand. Renamed
-/// from the old `pit_tick_isr` to make clear that a delivered interrupt is an
-/// event, not a unit of time.
+/// This accounts the scheduler quantum, expires deadlines, and rearms the
+/// one-shot clockevent for the next event — all before EOI. It does **not**
+/// advance the timeline: the timeline is read from the clocksource on demand.
+/// Renamed from the old `pit_tick_isr` to make clear that a delivered interrupt
+/// is an event, not a unit of time.
+///
+/// IRQ path (#68):
+/// ```text
+/// read now -> account quantum -> expire_due -> rearm -> (caller EOIs)
+/// ```
 pub fn handle_timer_event() {
     TIMER_EVENTS.fetch_add(1, Ordering::Relaxed);
-    crate::sys::proc::on_timer_tick();
-    // Expire deadline-blocked sleepers. The timeline is read from the
-    // clocksource on demand, so this uses monotonic_ns(), not the event count.
-    // Bounded hard-IRQ batch; overflow is drained post-irq_exit by
-    // sys::timer::process_deferred_expiry().
-    crate::sys::timer::expire_due(monotonic_ns());
+    let now = monotonic_ns();
+    // Account the scheduler quantum: set need_resched only if the running
+    // task's slice has actually elapsed, replacing the old per-tick reschedule.
+    crate::sys::preempt::account_quantum(now);
+    // Expire deadline-blocked sleepers. Bounded hard-IRQ batch; overflow is
+    // drained post-irq_exit by sys::timer::process_deferred_expiry().
+    crate::sys::timer::expire_due(now);
+    // Rearm the one-shot timer for the next earliest deadline or quantum, before
+    // EOI, so a deadline expiring during this IRQ is observed and not lost.
+    crate::driver::time::clockevent::rearm(now);
 }
 
 /// Diagnostic: number of timer events delivered since boot. Used by the

--- a/kernel/twilight_kernel/src/main.rs
+++ b/kernel/twilight_kernel/src/main.rs
@@ -255,9 +255,12 @@ pub fn init(
 
     driver::timer::init();
 
-    // Switch to APIC timer. Calibration busy-waits on the TSC, not on the
-    // interrupt-count clock, so it is correct under KVM (#62).
+    // Switch to APIC timer. Calibration busy-waits on the selected clocksource
+    // (TSC or HPET), not the interrupt-count clock, so it is correct under KVM
+    // and TCG (#62/#68). The LAPIC is programmed in one-shot mode as a
+    // clockevent; clockevent::init arms the first event.
     driver::apic::lapic::init();
+    driver::time::clockevent::init();
 
     // Establish the realtime epoch from the CMOS RTC. The RTC defines the
     // wall-clock origin; elapsed time thereafter comes from the selected

--- a/kernel/twilight_kernel/src/sys/preempt.rs
+++ b/kernel/twilight_kernel/src/sys/preempt.rs
@@ -5,7 +5,7 @@
 //! explicit `cond_resched()` safe point. The existing user-mode timer return
 //! path remains the only interrupt-context scheduling exception.
 
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 // Bootstrap implementation: userspace scheduling currently runs only on the
 // BSP, while APs remain in their halt loop. Twilight's existing CpuLocal<T>
@@ -20,6 +20,21 @@ static IRQ_DEPTH: AtomicUsize = AtomicUsize::new(0);
 static IN_SCHEDULER: AtomicBool = AtomicBool::new(false);
 
 static NEED_RESCHED: AtomicBool = AtomicBool::new(false);
+
+// --- Scheduler quantum (one-shot clockevent, #68) --------------------------
+//
+// The scheduler slice is an absolute monotonic deadline, not a per-tick counter.
+// `need_resched` is set only when `now >= QUANTUM_DEADLINE`, replacing the old
+// unconditional `set_need_resched()` every 1 ms tick. A deadline of 0 means no
+// quantum is armed (idle, or a single runnable task with no peer to preempt
+// for), so the clockevent stays disarmed and no periodic interrupts fire.
+
+/// Default scheduler slice length.
+pub const QUANTUM_NS: u64 = 10_000_000; // 10 ms
+
+/// Absolute monotonic deadline at which the running task's slice expires, or 0
+/// if no quantum is armed.
+static QUANTUM_DEADLINE: AtomicU64 = AtomicU64::new(0);
 
 // --- Kernel-preemption context trackers -----------------------------------
 //
@@ -201,6 +216,40 @@ pub fn clear_need_resched() {
 #[inline]
 pub fn need_resched() -> bool {
     NEED_RESCHED.load(Ordering::SeqCst)
+}
+
+// --- Quantum deadline API ---------------------------------------------------
+
+/// The armed quantum deadline, or `None` when no quantum is active (0 sentinel).
+#[inline]
+pub fn quantum_deadline_ns() -> Option<u64> {
+    let d = QUANTUM_DEADLINE.load(Ordering::SeqCst);
+    (d != 0).then_some(d)
+}
+
+/// Arm a fresh quantum: the slice expires at `now + QUANTUM_NS`. Called by the
+/// scheduler on context switch when another runnable task exists to preempt for.
+#[inline]
+pub fn reset_quantum(now_ns: u64) {
+    QUANTUM_DEADLINE.store(now_ns.saturating_add(QUANTUM_NS), Ordering::SeqCst);
+}
+
+/// Clear the quantum. Called when entering idle or when only one task is
+/// runnable, so no periodic preemption interrupts are needed.
+#[inline]
+pub fn clear_quantum() {
+    QUANTUM_DEADLINE.store(0, Ordering::SeqCst);
+}
+
+/// Account elapsed quantum time. Sets `need_resched` if the running task's
+/// slice has expired. Called from the timer ISR; replaces the old per-tick
+/// `set_need_resched()`.
+#[inline]
+pub fn account_quantum(now_ns: u64) {
+    let d = QUANTUM_DEADLINE.load(Ordering::SeqCst);
+    if d != 0 && now_ns >= d {
+        set_need_resched();
+    }
 }
 
 #[inline]

--- a/kernel/twilight_kernel/src/sys/preempt.rs
+++ b/kernel/twilight_kernel/src/sys/preempt.rs
@@ -242,13 +242,17 @@ pub fn clear_quantum() {
 }
 
 /// Account elapsed quantum time. Sets `need_resched` if the running task's
-/// slice has expired. Called from the timer ISR; replaces the old per-tick
-/// `set_need_resched()`.
+/// slice has expired, and clears the expired deadline so [`clockevent::rearm`]
+/// does not keep selecting a stale (past) quantum deadline on every event.
+/// Called from the timer ISR; replaces the old per-tick `set_need_resched()`.
 #[inline]
 pub fn account_quantum(now_ns: u64) {
     let d = QUANTUM_DEADLINE.load(Ordering::SeqCst);
     if d != 0 && now_ns >= d {
         set_need_resched();
+        // Clear so the next rearm arms only for a live software deadline (or
+        // disarms). The next context switch re-arms a fresh quantum.
+        QUANTUM_DEADLINE.store(0, Ordering::SeqCst);
     }
 }
 

--- a/kernel/twilight_kernel/src/sys/proc/mod.rs
+++ b/kernel/twilight_kernel/src/sys/proc/mod.rs
@@ -1714,8 +1714,18 @@ pub fn await_io() {
 /// (I/O or timeout) before returning.
 pub fn await_io_with_timeout(timeout_deadline_ns: Option<u64>) {
     let cur_pid = id();
+    // Token from the previous loop iteration, if any. Held across iterations so
+    // a retry explicitly cancels the outstanding wait before arming a fresh one,
+    // rather than relying on lazy queue reclamation to drop a stale entry (which
+    // would leave a spurious timer event armed for a dead deadline).
+    let mut outstanding_token: Option<crate::sys::timer::WaitToken> = None;
 
     loop {
+        // Cancel any token left over from a previous iteration before re-arming.
+        if let Some(tok) = outstanding_token.take() {
+            crate::sys::timer::cancel_owned(tok);
+        }
+
         let Some(scheduler_guard) = crate::sys::preempt::SchedulerGuard::try_enter() else {
             return;
         };
@@ -1776,6 +1786,9 @@ pub fn await_io_with_timeout(timeout_deadline_ns: Option<u64>) {
                     return; // Woken by wake_process explicitly setting state
                 }
             }
+            // Spurious wake: neither pending_io nor Running. Retry, carrying the
+            // outstanding token so the loop top cancels it before re-arming.
+            outstanding_token = io_token;
         } else {
             // No other runnable process. Stay logically AwaitingIo.
             drop(scheduler_guard);
@@ -1807,6 +1820,8 @@ pub fn await_io_with_timeout(timeout_deadline_ns: Option<u64>) {
                     return;
                 }
             }
+            // Spurious wake from halt: retry, carrying the outstanding token.
+            outstanding_token = io_token;
         }
     }
 }

--- a/kernel/twilight_kernel/src/sys/proc/mod.rs
+++ b/kernel/twilight_kernel/src/sys/proc/mod.rs
@@ -1425,6 +1425,36 @@ pub fn poll_wait_queue() -> &'static WaitQueue {
     &POLL_WAIT_QUEUE
 }
 
+/// Arm an I/O timeout deadline on the deadline queue and publish its token on
+/// `process`. Called by [`await_io_with_timeout`] under the scheduler guard,
+/// after the process has entered `AwaitingIo` state, so the timer expiry path
+/// (`wake_from_timer` with `IoTimeout`) can wake it.
+///
+/// Returns `None` if the token space is exhausted (the caller blocks without a
+/// timeout, which is safe — it will wake on I/O or never).
+fn arm_io_timeout_locked(
+    process: &mut Process,
+    deadline_ns: u64,
+) -> Option<crate::sys::timer::WaitToken> {
+    let token = crate::sys::timer::arm_current_locked(
+        deadline_ns,
+        crate::sys::timer::DeadlineKind::IoTimeout,
+    );
+    if token == crate::sys::timer::WaitToken::EXHAUSTED {
+        return None;
+    }
+    process.wait_token = Some(token);
+    process.wait_deadline_ns = Some(deadline_ns);
+    process.wake_reason = None;
+    // Final earliest-deadline recheck: reprogram the clockevent if this timeout
+    // is earlier than the currently armed event.
+    crate::driver::time::clockevent::rearm_if_earlier(
+        crate::driver::time::monotonic_ns(),
+        deadline_ns,
+    );
+    Some(token)
+}
+
 fn initial_context_stack_top(kernel_rsp: u64) -> u64 {
     kernel_rsp - INITIAL_CONTEXT_STACK_GUARD
 }
@@ -1632,11 +1662,6 @@ pub fn terminate_current_by_signal(sig: i32) -> ! {
     }
 }
 
-pub fn on_timer_tick() {
-    crate::sys::preempt::set_need_resched();
-    POLL_WAIT_QUEUE.notify_all();
-}
-
 pub fn maybe_schedule() {
     crate::sys::preempt::cond_resched();
 }
@@ -1678,6 +1703,16 @@ pub fn schedule_now() -> bool {
 }
 
 pub fn await_io() {
+    await_io_with_timeout(None);
+}
+
+/// Block on I/O with an optional absolute monotonic timeout deadline (#68).
+///
+/// When `timeout_deadline_ns` is `Some`, an I/O timeout is armed on the deadline
+/// queue after the process enters `AwaitingIo` state, so the one-shot clockevent
+/// wakes us exactly when the timeout expires. The token is cancelled on any wake
+/// (I/O or timeout) before returning.
+pub fn await_io_with_timeout(timeout_deadline_ns: Option<u64>) {
     let cur_pid = id();
 
     loop {
@@ -1712,6 +1747,13 @@ pub fn await_io() {
 
         slice[cur_idx].state = ProcessState::AwaitingIo;
 
+        // Arm the I/O timeout after entering AwaitingIo, so wake_from_timer
+        // (which only wakes AwaitingIo processes for IoTimeout) can fire. The
+        // token is published on the process under the scheduler guard.
+        let io_token = timeout_deadline_ns.and_then(|deadline| {
+            arm_io_timeout_locked(&mut slice[cur_idx], deadline)
+        });
+
         if let Some(next_idx) = find_next_runnable_index(slice, cur_idx) {
             switch_by_index_guarded(slice, cur_idx, next_idx, scheduler_guard);
 
@@ -1722,9 +1764,15 @@ pub fn await_io() {
             if let Some(process) = table.get_process(cur_pid) {
                 if process.pending_io {
                     process.pending_io = false;
+                    if let Some(tok) = io_token {
+                        crate::sys::timer::cancel_owned(tok);
+                    }
                     return;
                 }
                 if matches!(process.state, ProcessState::Running) {
+                    if let Some(tok) = io_token {
+                        crate::sys::timer::cancel_owned(tok);
+                    }
                     return; // Woken by wake_process explicitly setting state
                 }
             }
@@ -1744,12 +1792,18 @@ pub fn await_io() {
                     if matches!(process.state, ProcessState::Runnable) {
                         process.state = ProcessState::Running;
                     }
+                    if let Some(tok) = io_token {
+                        crate::sys::timer::cancel_owned(tok);
+                    }
                     return;
                 }
                 if matches!(process.state, ProcessState::Runnable) {
                     // No context switch occurred: this task is still the BSP
                     // current task and is resuming directly after HLT.
                     process.state = ProcessState::Running;
+                    if let Some(tok) = io_token {
+                        crate::sys::timer::cancel_owned(tok);
+                    }
                     return;
                 }
             }
@@ -1782,14 +1836,23 @@ pub fn wake_process(pid: u16) {
     }
 }
 
-/// Wake a deadline-blocked process from the timer expiry path (#66).
+/// Wake a deadline-blocked process from the timer expiry path (#66/#68).
 ///
 /// The `token` must match the process's currently published `wait_token`; a
 /// mismatch (stale/cancelled entry, or PID reuse) is a no-op. This is the
 /// stale-entry guard that prevents a cancelled wait from waking a later one.
 /// Called from hard-IRQ context by `sys::timer::expire_due` after the queue
 /// guard has been released.
-pub fn wake_from_timer(pid: u16, token: crate::sys::timer::WaitToken) {
+///
+/// `kind` selects the wakeup semantics: a `Sleep` deadline wakes a `Sleeping`
+/// process; an `IoTimeout` deadline wakes an `AwaitingIo` process (e.g. a
+/// `poll`/`select` timeout) and sets `pending_io` so the `await_io` loop treats
+/// it as a genuine wake.
+pub fn wake_from_timer(
+    pid: u16,
+    token: crate::sys::timer::WaitToken,
+    kind: crate::sys::timer::DeadlineKind,
+) {
     let _preempt_guard = crate::sys::preempt::PreemptGuard::new();
     #[allow(static_mut_refs)]
     let Some(table) = (unsafe { PROCESS_TABLE.get_mut() }) else {
@@ -1798,15 +1861,32 @@ pub fn wake_from_timer(pid: u16, token: crate::sys::timer::WaitToken) {
     let Some(process) = table.get_process(pid) else {
         return;
     };
-    // Only wake a Sleeping process whose published token matches. A stale or
-    // already-woken entry cannot wake a later wait.
-    if process.wait_token != Some(token) || !matches!(process.state, ProcessState::Sleeping) {
+    if process.wait_token != Some(token) {
         return;
     }
-    process.state = ProcessState::Runnable;
-    process.wait_token = None;
-    process.wait_deadline_ns = None;
-    process.wake_reason = Some(crate::sys::timer::WakeReason::Deadline);
+    match kind {
+        crate::sys::timer::DeadlineKind::Sleep => {
+            if !matches!(process.state, ProcessState::Sleeping) {
+                return;
+            }
+            process.state = ProcessState::Runnable;
+            process.wait_token = None;
+            process.wait_deadline_ns = None;
+            process.wake_reason = Some(crate::sys::timer::WakeReason::Deadline);
+        }
+        crate::sys::timer::DeadlineKind::IoTimeout => {
+            if !matches!(process.state, ProcessState::AwaitingIo) {
+                return;
+            }
+            // Treat the timeout as an I/O wake: the await_io loop will see
+            // pending_io and re-check its fds / deadline.
+            process.state = ProcessState::Runnable;
+            process.pending_io = true;
+            process.wait_token = None;
+            process.wait_deadline_ns = None;
+            process.wake_reason = None;
+        }
+    }
 }
 
 /// Clear any outstanding wait token on a process about to exit or be killed.
@@ -1921,6 +2001,18 @@ fn find_next_runnable_index(processes: &[Process], current_idx: usize) -> Option
     None
 }
 
+/// Arm or clear the scheduler quantum after selecting `current_idx` as the new
+/// running task. If another runnable peer exists, arm a fresh quantum so the
+/// one-shot clockevent preempts the slice when it elapses; otherwise clear it so
+/// idle/single-task workloads need no periodic interrupts (#68).
+fn arm_quantum_for_current(processes: &[Process], current_idx: usize) {
+    if find_next_runnable_index(processes, current_idx).is_some() {
+        crate::sys::preempt::reset_quantum(crate::driver::time::monotonic_ns());
+    } else {
+        crate::sys::preempt::clear_quantum();
+    }
+}
+
 /// Validate the BSP invariant at a stable scheduler boundary: exactly one
 /// process-table entry is Running, and it is the process selected for the CPU.
 fn validate_running_owner(processes: &[Process], expected_idx: usize) -> bool {
@@ -1990,6 +2082,12 @@ fn switch_tasks_with_new_scheduler_guard(current: &mut Process, next: &mut Proce
     }
     next.state = ProcessState::Running;
     crate::sys::preempt::clear_need_resched();
+    // This kernel-context switch path (exec/spawn/init) does not have the full
+    // process slice, so it cannot check for a runnable peer. Clear the quantum;
+    // the next schedule_now() through switch_by_index_guarded() will arm it if
+    // a peer exists. Rearm the clockevent so the disarmed state takes effect.
+    crate::sys::preempt::clear_quantum();
+    crate::driver::time::clockevent::rearm(crate::driver::time::monotonic_ns());
     scheduler_guard.release_before_switch();
     switch_tasks(current, next);
     true
@@ -2024,6 +2122,11 @@ fn switch_by_index_guarded(
         return false;
     }
 
+    // Arm the scheduler quantum for the new current task iff another runnable
+    // task exists to preempt for. With no peer, clear the quantum so the
+    // one-shot clockevent stays disarmed and no periodic preemption fires.
+    arm_quantum_for_current(processes, next_idx);
+
     let ptr = processes.as_mut_ptr();
     unsafe {
         let cur = &mut *ptr.add(cur_idx);
@@ -2055,6 +2158,11 @@ fn switch_by_index_guarded(
 /// The caller must have already dropped its `SchedulerGuard` so [`schedule_now`]
 /// can re-enter the scheduler.
 fn idle_until_runnable() -> ! {
+    // No runnable peer: clear the quantum so the one-shot clockevent is armed
+    // only for the earliest sleeper deadline (if any). Idle with no deadlines
+    // disarms the timer entirely — no periodic interrupts (#68).
+    crate::sys::preempt::clear_quantum();
+    crate::driver::time::clockevent::rearm(crate::driver::time::monotonic_ns());
     loop {
         crate::task::executor::halt();
         // Re-check for a runnable task. schedule_now() switches away if one
@@ -2064,9 +2172,9 @@ fn idle_until_runnable() -> ! {
 }
 
 fn timer_preempt_common(frame: *mut PreemptFrame, from_user: u64) -> *mut PreemptFrame {
-    // need_resched is already set by on_timer_tick() (called via
-    // driver::time::handle_timer_event before this function). The logic below
-    // decides whether to act on it now.
+    // need_resched is set by account_quantum() (called via
+    // driver::time::handle_timer_event before this function) when the running
+    // task's quantum has elapsed. The logic below decides whether to act on it.
 
     // Drain deadline-queue overflow outside hard-IRQ context. expire_due()
     // (called from handle_timer_event under irq_enter) processes a bounded
@@ -2086,8 +2194,8 @@ fn timer_preempt_common(frame: *mut PreemptFrame, from_user: u64) -> *mut Preemp
     // can_preempt_kernel() is satisfied.
     if crate::sys::preempt::ENABLE_KERNEL_PREEMPTION {
         if crate::sys::preempt::can_preempt_kernel() {
-            let rip = unsafe { (*frame).rip };
-            let rsp = unsafe { (*frame).rsp };
+            let _rip = unsafe { (*frame).rip };
+            let _rsp = unsafe { (*frame).rsp };
             // crate::serial_println!(
             //     "[kpreempt] allow: pid={} rip={:#x} rsp={:#x}",
             //     id(),

--- a/kernel/twilight_kernel/src/sys/syscall/service.rs
+++ b/kernel/twilight_kernel/src/sys/syscall/service.rs
@@ -3583,17 +3583,22 @@ pub fn poll(fds_ptr: usize, nfds: usize, timeout_ms: isize) -> i64 {
     }
 
     let infinite = timeout_ms < 0;
-    let start = uptime();
-    let deadline = if infinite {
+    // Absolute monotonic deadline in ns for the deadline queue (#68). A finite
+    // poll timeout is delivered as a one-shot clockevent rather than relying on
+    // a periodic tick to wake this loop.
+    let deadline_ns = if infinite {
         None
     } else {
-        Some(start + (timeout_ms as f64) / 1000.0)
+        let now_ns = crate::driver::time::monotonic_ns();
+        // timeout_ms in ms -> ns; saturate to avoid overflow on huge values.
+        let delta_ns = (timeout_ms as u64).saturating_mul(1_000_000);
+        Some(now_ns.saturating_add(delta_ns))
     };
     let wait_queue = sys::proc::poll_wait_queue();
 
     loop {
-        if let Some(limit) = deadline {
-            if uptime() >= limit {
+        if let Some(deadline) = deadline_ns {
+            if crate::driver::time::monotonic_ns() >= deadline {
                 return 0;
             }
         }
@@ -3613,14 +3618,17 @@ pub fn poll(fds_ptr: usize, nfds: usize, timeout_ms: isize) -> i64 {
             return ready as i64;
         }
 
-        if let Some(limit) = deadline {
-            if uptime() >= limit {
+        if let Some(deadline) = deadline_ns {
+            if crate::driver::time::monotonic_ns() >= deadline {
                 wait_queue.finish_wait(wait_pid);
                 return 0;
             }
         }
 
-        sys::proc::await_io();
+        // Block on I/O with the timeout deadline armed on the one-shot
+        // clockevent. await_io_with_timeout arms/cancels the IoTimeout token
+        // itself after entering AwaitingIo state, closing the arm-vs-wake race.
+        sys::proc::await_io_with_timeout(deadline_ns);
         wait_queue.finish_wait(wait_pid);
 
         ready = match poll_fd_set_for_pid(fds, current_pid) {
@@ -3660,23 +3668,24 @@ pub fn ppoll(
         return ready as i64;
     }
 
-    let deadline = if tmo_p != 0 {
+    let deadline_ns = if tmo_p != 0 {
         let ts_ptr = tmo_p as *const Timespec;
         let ts = unsafe { &*ts_ptr };
         if ts.tv_sec == 0 && ts.tv_nsec == 0 {
             return 0;
         }
-        let now = uptime();
-        let dur = (ts.tv_sec as f64) + (ts.tv_nsec as f64) / 1_000_000_000.0;
-        Some(now + dur)
+        let now_ns = crate::driver::time::monotonic_ns();
+        let delta_ns = (ts.tv_sec as u64).saturating_mul(1_000_000_000)
+            .saturating_add(ts.tv_nsec as u64);
+        Some(now_ns.saturating_add(delta_ns))
     } else {
         None
     };
     let wait_queue = sys::proc::poll_wait_queue();
 
     loop {
-        if let Some(limit) = deadline {
-            if uptime() >= limit {
+        if let Some(deadline) = deadline_ns {
+            if crate::driver::time::monotonic_ns() >= deadline {
                 return 0;
             }
         }
@@ -3699,14 +3708,17 @@ pub fn ppoll(
             return ready as i64;
         }
 
-        if let Some(limit) = deadline {
-            if uptime() >= limit {
+        if let Some(deadline) = deadline_ns {
+            if crate::driver::time::monotonic_ns() >= deadline {
                 wait_queue.finish_wait(wait_pid);
                 return 0;
             }
         }
 
-        sys::proc::await_io();
+        // Block on I/O with the timeout deadline armed on the one-shot
+        // clockevent. await_io_with_timeout arms/cancels the IoTimeout token
+        // itself after entering AwaitingIo state, closing the arm-vs-wake race.
+        sys::proc::await_io_with_timeout(deadline_ns);
         wait_queue.finish_wait(wait_pid);
 
         ready = match poll_fd_set_for_pid(fds, current_pid) {
@@ -3779,17 +3791,20 @@ pub fn select(
             if tv.tv_sec == 0 && tv.tv_usec == 0 {
                 return 0;
             }
-            let total_ms = tv.tv_sec * 1000 + (tv.tv_usec as i64) / 1000 + 1;
-            let start = uptime();
+            let now_ns = crate::driver::time::monotonic_ns();
+            let delta_ns = (tv.tv_sec as u64)
+                .saturating_mul(1_000_000_000)
+                .saturating_add((tv.tv_usec as u64).saturating_mul(1_000));
+            let deadline = now_ns.saturating_add(delta_ns);
             loop {
-                if uptime() >= start + (total_ms as f64) / 1000.0 {
+                if crate::driver::time::monotonic_ns() >= deadline {
                     return 0;
                 }
-                sys::proc::await_io();
+                sys::proc::await_io_with_timeout(Some(deadline));
             }
         }
         loop {
-            sys::proc::await_io();
+            sys::proc::await_io_with_timeout(None);
         }
     }
 
@@ -3816,23 +3831,25 @@ pub fn select(
     }
 
     let timeout_is_null = timeout_ptr == 0;
-    let deadline = if timeout_is_null {
+    let deadline_ns = if timeout_is_null {
         None
     } else {
         let tv = unsafe { &*(timeout_ptr as *const Timeval) };
         if tv.tv_sec == 0 && tv.tv_usec == 0 {
             return 0;
         }
-        let now = uptime();
-        let dur = (tv.tv_sec as f64) + (tv.tv_usec as f64) / 1_000_000.0;
-        Some(now + dur)
+        let now_ns = crate::driver::time::monotonic_ns();
+        let delta_ns = (tv.tv_sec as u64)
+            .saturating_mul(1_000_000_000)
+            .saturating_add((tv.tv_usec as u64).saturating_mul(1_000));
+        Some(now_ns.saturating_add(delta_ns))
     };
 
     let wait_queue = sys::proc::poll_wait_queue();
 
     loop {
-        if let Some(limit) = deadline {
-            if uptime() >= limit {
+        if let Some(deadline) = deadline_ns {
+            if crate::driver::time::monotonic_ns() >= deadline {
                 return 0;
             }
         }
@@ -3862,14 +3879,17 @@ pub fn select(
             return ready as i64;
         }
 
-        if let Some(limit) = deadline {
-            if uptime() >= limit {
+        if let Some(deadline) = deadline_ns {
+            if crate::driver::time::monotonic_ns() >= deadline {
                 wait_queue.finish_wait(wait_pid);
                 return 0;
             }
         }
 
-        sys::proc::await_io();
+        // Block on I/O with the timeout deadline armed on the one-shot
+        // clockevent. await_io_with_timeout arms/cancels the IoTimeout token
+        // itself after entering AwaitingIo state, closing the arm-vs-wake race.
+        sys::proc::await_io_with_timeout(deadline_ns);
         wait_queue.finish_wait(wait_pid);
 
         ready = match poll_fd_set_for_pid(pfds, current_pid) {

--- a/kernel/twilight_kernel/src/sys/syscall/service.rs
+++ b/kernel/twilight_kernel/src/sys/syscall/service.rs
@@ -3674,9 +3674,13 @@ pub fn ppoll(
         if ts.tv_sec == 0 && ts.tv_nsec == 0 {
             return 0;
         }
+        // Validate before the unsigned conversion: a negative tv_sec would
+        // otherwise cast to a huge u64 and block for ~584 years.
+        if let Err(e) = crate::sys::syscall::time::validate_timespec(ts) {
+            return e;
+        }
         let now_ns = crate::driver::time::monotonic_ns();
-        let delta_ns = (ts.tv_sec as u64).saturating_mul(1_000_000_000)
-            .saturating_add(ts.tv_nsec as u64);
+        let delta_ns = crate::sys::syscall::time::timespec_to_ns(ts);
         Some(now_ns.saturating_add(delta_ns))
     } else {
         None
@@ -3791,6 +3795,11 @@ pub fn select(
             if tv.tv_sec == 0 && tv.tv_usec == 0 {
                 return 0;
             }
+            // Validate before the unsigned conversion: a negative tv_sec would
+            // otherwise cast to a huge u64 and block for ~584 years.
+            if !valid_timeval(*tv) {
+                return -(EINVAL as i64);
+            }
             let now_ns = crate::driver::time::monotonic_ns();
             let delta_ns = (tv.tv_sec as u64)
                 .saturating_mul(1_000_000_000)
@@ -3837,6 +3846,11 @@ pub fn select(
         let tv = unsafe { &*(timeout_ptr as *const Timeval) };
         if tv.tv_sec == 0 && tv.tv_usec == 0 {
             return 0;
+        }
+        // Validate before the unsigned conversion: a negative tv_sec would
+        // otherwise cast to a huge u64 and block for ~584 years.
+        if !valid_timeval(*tv) {
+            return -(EINVAL as i64);
         }
         let now_ns = crate::driver::time::monotonic_ns();
         let delta_ns = (tv.tv_sec as u64)

--- a/kernel/twilight_kernel/src/sys/syscall/time.rs
+++ b/kernel/twilight_kernel/src/sys/syscall/time.rs
@@ -355,9 +355,15 @@ mod tests {
 
     #[test]
     fn ns_to_timespec_splits_correctly() {
+        // `Timespec` is #[repr(C, packed)], so field accesses go through a
+        // raw pointer read to avoid an unaligned reference (E0793).
         let t = ns_to_timespec(1_500_000_007);
-        assert_eq!(t.tv_sec, 1);
-        assert_eq!(t.tv_nsec, 500_000_007);
+        let sec = core::ptr::addr_of!(t.tv_sec);
+        let nsec = core::ptr::addr_of!(t.tv_nsec);
+        unsafe {
+            assert_eq!(*sec, 1);
+            assert_eq!(*nsec, 500_000_007);
+        }
     }
 
     #[test]

--- a/kernel/twilight_kernel/src/sys/syscall/time.rs
+++ b/kernel/twilight_kernel/src/sys/syscall/time.rs
@@ -42,7 +42,7 @@ enum SleepOutcome {
 
 /// Validate a `Timespec`'s fields. POSIX requires `tv_sec >= 0` and
 /// `0 <= tv_nsec < 1_000_000_000`.
-fn validate_timespec(req: &Timespec) -> Result<(), i64> {
+pub(crate) fn validate_timespec(req: &Timespec) -> Result<(), i64> {
     if req.tv_sec < 0 || req.tv_nsec < 0 || req.tv_nsec >= NSEC_PER_SEC as i64 {
         return Err(-(EINVAL as i64));
     }
@@ -52,7 +52,7 @@ fn validate_timespec(req: &Timespec) -> Result<(), i64> {
 /// Convert a validated `Timespec` to integer nanoseconds using checked/saturating
 /// `u128` arithmetic. Saturates to `u64::MAX`; never wraps into an immediate
 /// deadline. No `f64`.
-fn timespec_to_ns(req: &Timespec) -> u64 {
+pub(crate) fn timespec_to_ns(req: &Timespec) -> u64 {
     let secs = req.tv_sec as u128;
     let nsec = req.tv_nsec as u128;
     let total = secs.saturating_mul(NSEC_PER_SEC as u128).saturating_add(nsec);
@@ -356,13 +356,16 @@ mod tests {
     #[test]
     fn ns_to_timespec_splits_correctly() {
         // `Timespec` is #[repr(C, packed)], so field accesses go through a
-        // raw pointer read to avoid an unaligned reference (E0793).
+        // raw pointer read to avoid an unaligned reference (E0793). Use
+        // read_unaligned rather than a direct deref, which would still be UB on
+        // a packed field whose address is not aligned.
         let t = ns_to_timespec(1_500_000_007);
-        let sec = core::ptr::addr_of!(t.tv_sec);
-        let nsec = core::ptr::addr_of!(t.tv_nsec);
         unsafe {
-            assert_eq!(*sec, 1);
-            assert_eq!(*nsec, 500_000_007);
+            assert_eq!(core::ptr::read_unaligned(core::ptr::addr_of!(t.tv_sec)), 1);
+            assert_eq!(
+                core::ptr::read_unaligned(core::ptr::addr_of!(t.tv_nsec)),
+                500_000_007
+            );
         }
     }
 

--- a/kernel/twilight_kernel/src/sys/timer/mod.rs
+++ b/kernel/twilight_kernel/src/sys/timer/mod.rs
@@ -128,6 +128,12 @@ pub fn block_current_until(deadline_ns: u64) -> WakeReason {
         cur.wait_deadline_ns = Some(deadline_ns);
         cur.wake_reason = None;
         cur.state = crate::sys::proc::ProcessState::Sleeping;
+
+        // Final earliest-deadline recheck before leaving the critical section:
+        // if this new deadline is earlier than the currently armed clockevent,
+        // atomically reprogram the LAPIC now. This closes the insertion-vs-IRQ
+        // race so an earlier deadline cannot be delayed behind an older event.
+        crate::driver::time::clockevent::rearm_if_earlier(now, deadline_ns);
     }
 
     // (6) Release the scheduler guard before switching. The next task may enter
@@ -211,13 +217,12 @@ fn read_and_clear_wake_reason(cur_pid: u16, deadline_ns: u64) -> WakeReason {
 }
 
 /// Arm a wait for the current process and return its token. Called by
-/// `block_current_until` and available to other subsystems (e.g. I/O timeouts)
-/// that publish their own blocked state under the same contract.
+/// `block_current_until` and by [`proc::arm_io_timeout_locked`] for poll/select
+/// timeouts, which publish their own blocked state under the same contract.
 ///
 /// The caller must hold the scheduler guard and have already validated the
 /// deadline against the clock. Returns [`WaitToken::EXHAUSTED`] if the token
 /// space is exhausted (do not block in that case).
-#[allow(dead_code)]
 pub(crate) fn arm_current_locked(deadline_ns: u64, kind: DeadlineKind) -> WaitToken {
     let cur_pid = crate::sys::proc::id();
     let mut q = TIMER_QUEUE.lock_irq();
@@ -242,10 +247,10 @@ pub(crate) fn arm_current_locked(deadline_ns: u64, kind: DeadlineKind) -> WaitTo
 /// dead. Safe to call with a token that is no longer live (no-op).
 ///
 /// This is the explicit cancellation primitive for paths that abort a wait
-/// without exiting (e.g. a POSIX signal interrupting a sleep). The exit path
-/// uses the lighter `proc::invalidate_wait_token`, which clears the same field
-/// without taking the queue lock; both rely on lazy reclamation.
-#[allow(dead_code)]
+/// without exiting (e.g. a POSIX signal interrupting a sleep, or an early I/O
+/// wake cancelling a poll timeout). The exit path uses the lighter
+/// `proc::invalidate_wait_token`, which clears the same field without taking
+/// the queue lock; both rely on lazy reclamation.
 pub(crate) fn cancel_owned(token: WaitToken) {
     let cur_pid = crate::sys::proc::id();
     {
@@ -273,7 +278,8 @@ pub(crate) fn cancel_owned(token: WaitToken) {
 pub fn expire_due(now_ns: u64) {
     // Collect a bounded batch of due entries without holding the queue while
     // waking processes.
-    let mut batch: [Option<(u16, WaitToken)>; EXPIRY_BATCH] = [const { None }; EXPIRY_BATCH];
+    let mut batch: [Option<(u16, WaitToken, DeadlineKind)>; EXPIRY_BATCH] =
+        [const { None }; EXPIRY_BATCH];
     let mut count = 0;
     let more_due;
     {
@@ -281,7 +287,7 @@ pub fn expire_due(now_ns: u64) {
         while count < EXPIRY_BATCH {
             match q.pop_due(now_ns, is_live_wait) {
                 Some(e) => {
-                    batch[count] = Some((e.pid, e.token));
+                    batch[count] = Some((e.pid, e.token, e.kind));
                     count += 1;
                 }
                 None => break,
@@ -294,8 +300,8 @@ pub fn expire_due(now_ns: u64) {
     }
     // Queue guard dropped: wake processes without holding it.
     for i in 0..count {
-        if let Some((pid, token)) = batch[i] {
-            crate::sys::proc::wake_from_timer(pid, token);
+        if let Some((pid, token, kind)) = batch[i] {
+            crate::sys::proc::wake_from_timer(pid, token, kind);
         }
     }
     if more_due {
@@ -311,7 +317,8 @@ pub fn process_deferred_expiry() {
         return;
     }
     let now_ns = crate::driver::time::monotonic_ns();
-    let mut batch: [Option<(u16, WaitToken)>; EXPIRY_BATCH] = [const { None }; EXPIRY_BATCH];
+    let mut batch: [Option<(u16, WaitToken, DeadlineKind)>; EXPIRY_BATCH] =
+        [const { None }; EXPIRY_BATCH];
     loop {
         let mut count = 0;
         let more_due;
@@ -320,7 +327,7 @@ pub fn process_deferred_expiry() {
             while count < EXPIRY_BATCH {
                 match q.pop_due(now_ns, is_live_wait) {
                     Some(e) => {
-                        batch[count] = Some((e.pid, e.token));
+                        batch[count] = Some((e.pid, e.token, e.kind));
                         count += 1;
                     }
                     None => break,
@@ -331,8 +338,8 @@ pub fn process_deferred_expiry() {
                 .is_some_and(|d| d <= now_ns);
         }
         for i in 0..count {
-            if let Some((pid, token)) = batch[i] {
-                crate::sys::proc::wake_from_timer(pid, token);
+            if let Some((pid, token, kind)) = batch[i] {
+                crate::sys::proc::wake_from_timer(pid, token, kind);
             }
         }
         if !more_due {
@@ -340,6 +347,8 @@ pub fn process_deferred_expiry() {
         }
     }
     DEFERRED_EXPIRY_PENDING.store(false, core::sync::atomic::Ordering::SeqCst);
+    // Rearm for the next earliest deadline after draining overflow.
+    crate::driver::time::clockevent::rearm(crate::driver::time::monotonic_ns());
 }
 
 /// Earliest live deadline, or `None` if no live waits exist. Stale heads are


### PR DESCRIPTION
Closes #68.

## Summary

Converts the x86 LAPIC timer from a fixed 1 kHz periodic interrupt into a one-shot clockevent programmed for `min(earliest software deadline, scheduler quantum deadline)`. The periodic tick is removed entirely as a delivery mechanism for scheduler preemption and poll/select timeouts.

### Three-layer architecture (mirrors Linux)

- **`driver/apic/lapic.rs` — mechanism.** One-shot mode with fixed-point calibration against the selected continuous clocksource (`monotonic_ns`), not a TSC-domain busy-wait. Wide `u128` multiply-before-divide with ceiling; rejects bad calibration and falls back to periodic. Clamps due/beyond-range deltas. Public API: `program_oneshot_ns` / `cancel_timer` / `min_delta_ns` / `max_delta_ns`.
- **`driver/time/clockevent.rs` — policy.** Armed-event state as an `AtomicU64` with CAS compare/replace so an earlier insertion cannot be delayed behind an older programmed deadline (the final earliest-deadline recheck). Programs `min(next_deadline, quantum_deadline)` or disarms.
- **`sys/timer` + `sys/preempt` + `sys/proc` — consumers.** Deadline-queue inserts call `rearm_if_earlier` inside the `lock_irq` critical section; the scheduler quantum is an absolute monotonic deadline armed only when a runnable peer exists.

## Root causes fixed

1. **Calibration domain mismatch** — LAPIC ticks were calibrated against a TSC busy-wait while deadlines are measured in `monotonic_ns` (HPET under TCG). Now calibrated against the actual observed clocksource interval.
2. **Poll/select timeouts** relied on the periodic tick's `POLL_WAIT_QUEUE.notify_all` every 1 ms. Now delivered as `IoTimeout` entries on the deadline queue, woken by the one-shot clockevent exactly when the timeout expires.
3. **Per-tick `set_need_resched`** replaced by quantum-deadline accounting: `need_resched` fires only when the running task's slice has actually elapsed.
4. **Arm-vs-wake race** in poll/select: arming an `IoTimeout` before the process enters `AwaitingIo` state could be dropped by `wake_from_timer`'s state check. Folded arming into `await_io_with_timeout` after the state transition, under the scheduler guard.

## Invariants

- The clockevent never advances `CLOCK_MONOTONIC`; it only reads it.
- IRQ path is allocation-free with a fixed batch budget; locks released before wakeup.
- All due timers are observed before programming the next event.
- An earlier insertion cannot be delayed (CAS final-recheck).
- Scheduler fairness is independent of sleep count.
- Idle with no deadlines disarms the timer → no interrupts fire.

## IRQ path order

```
irq_enter → read now → account quantum → expire_due → rearm → EOI → irq_exit → deferred schedule
```

Vector `0xFD` and `idt.rs` are unchanged.

## Testing

- Unit tests: LAPIC `ns↔ticks` ceiling/clamping/floor; clockevent sentinel / earliest-of-two / CAS ordering. Host test harness compile-checks invariants (the `#![no_main]` bin crate cannot link a host test binary — pre-existing limitation; regression matrix is the real gate).
- Full regression matrix (`make test-time`): **tcg + kvm × smp1/4**, all cells `early=0 backward=0 failures=0`. The TCG cell (clocksource = HPET) is the critical regression case for the calibration-domain fix and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added calibrated one-shot timer operation for precise scheduling, with a reliable periodic fallback.
  * Added deadline-based I/O timeouts for polling, selection, and timed waits.
  * Added automatic timer rearming and cancellation as deadlines change.
  * Added scheduler quantum tracking to support timely preemption.

* **Bug Fixes**
  * Improved timeout calculations using monotonic time and safer, overflow-resistant arithmetic.
  * Improved handling of timer wakeups, overlapping deadlines, and earlier newly scheduled deadlines.
  * Added safer timer limits and fallback behavior when calibration is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->