### PR TITLE
feat(kernel): audit IRQ-shared locks and nest-safe lock_irq (#70)

### DIFF
--- a/docs/kernel-locking.md
+++ b/docs/kernel-locking.md
@@ -1,0 +1,129 @@
+# Kernel locking
+
+Twilight's kernel is single-CPU and **non-preemptive** (`ENABLE_KERNEL_PREEMPTION =
+false`). Concurrency is therefore bounded: the only way a second context can run
+"concurrently" with a task-context critical section is an **external interrupt**
+arriving while interrupts are enabled. This document is the audit of every lock
+that can be acquired from both task context (IF on) and IRQ context (IF cleared
+by hardware on entry) — the *IRQ-shared* locks — and the rules that keep them
+deadlock-free.
+
+## The two Mutex flavors
+
+`crate::utils::sync::Mutex` wraps `spin::Mutex` and offers two acquisition modes:
+
+- **`lock()`** — disables preemption only. Interrupts stay on. Use this for locks
+  that are **never** acquired from an IRQ handler on the same CPU.
+- **`lock_irq()`** — disables interrupts (nest-safe) **and** preemption. Use this
+  for any lock that is acquired from at least one IRQ handler, regardless of
+  whether the other site is task or IRQ context.
+
+The rule is one-directional and absolute:
+
+> If a lock is *ever* acquired from an interrupt handler, **every** acquisition
+> must use `lock_irq()`. A single `lock()` site on an IRQ-shared lock is a
+> deadlock: the task-context holder spins with IF on, the IRQ fires, the handler
+  tries to acquire the same lock, and spins forever because the holder can never
+> make progress.
+
+### Nest-safe IRQ disable
+
+`lock_irq()` and `IrqGuard` route through `preempt::irq_save()` /
+`preempt::irq_restore()`, which maintain a per-CPU depth counter
+(`IRQ_DISABLE_DEPTH`). An inner `lock_irq()` made while interrupts are already off
+increments the depth but records `was_enabled = false`, so its matching restore
+does **not** re-enable interrupts prematurely. Only the outermost guard whose
+`irq_save()` observed IF=1 re-enables. This makes nested `lock_irq()` calls safe.
+
+## Why syscalls don't need `lock_irq()` for `PROCESS_TABLE`
+
+`PROCESS_TABLE` is a `Once<ProcessTable>` accessed via raw `get_mut()` — no spin
+lock at all. This is safe because of two invariants:
+
+1. **Syscalls run with IF cleared.** `IA32_FMASK = 0x300` clears RFLAGS.IF on
+   `syscall` entry, and the return path executes `cli` before restoring
+   userspace. No syscall handler re-enables interrupts. So a syscall's
+   `PROCESS_TABLE` access cannot be interrupted by the timer IRQ.
+2. **The timer path is single-CPU non-concurrent.** `wake_from_timer` runs either
+   under `irq_enter` (hard-IRQ context, IF off) or in `process_deferred_expiry`
+   after `irq_exit` — but the latter runs in the interrupted task's own context,
+   not alongside it. There is no second CPU.
+
+Because both accessors have IF off (or are the same context), there is no
+reentrant access. Wrapping every `PROCESS_TABLE.get_mut()` in an `IrqGuard` would
+be redundant noise. The same reasoning applies to `UCHI_DEVICES` and the other
+`Once<T>` / `static mut` structures accessed from both init and IRQ handlers:
+init runs before interrupts are enabled, and the IRQ handler runs with IF off.
+
+## IRQ-shared lock inventory
+
+Every lock below is acquired from at least one IRQ handler. All sites use
+`lock_irq()`.
+
+| Lock | Location | Task-context sites | IRQ-context sites |
+|------|----------|--------------------|--------------------|
+| `PICS` | `arch/x86_64/idt.rs` | `init_pics`, `register_irq_handler`, `main` PIT mask | `dispatch_irq` EOI, `timer_preempt` EOI, keyboard/mouse ISR EOI |
+| `Tty.input_buffer` | `sys/console/tty.rs` | `input_read_ready`, `pop_input_now`, `poll`, `ioctl` TCSETSF | keyboard ISR → `put_input`, UART IRQ4 → `put_char_in_tty` |
+| `KEY_EVENT_QUEUE` | `driver/keyboard/mod.rs` | `KeyboardDev::pop_events`, `poll` | keyboard ISR → `enqueue_key_event` |
+| `PACKETS` | `driver/mouse/mod.rs` | `MouseDev::read`, `poll` | mouse ISR → `enqueue_packet` |
+| `TIMER_QUEUE` | `sys/timer/mod.rs` | `block_current_until`, `cancel_wait`, inserters | timer ISR → `expire_due`, `process_deferred_expiry` |
+| `WaitQueue.waiters` | `utils/sync.rs` | `prepare_current`, `finish_wait` | keyboard/UART ISR → `notify_all`, timer → `notify_one` |
+
+### Locks that are IRQ-context-only (not shared)
+
+`KEYBOARD`, `PS2_KEYBOARD_STATE`, and `PACKET_STATE` are acquired only from their
+respective ISRs today. They use `lock_irq()` for contract consistency and
+future-safety: if a task-context reader is ever added, it will already be correct.
+
+## Allocation-free WaitQueue
+
+`WaitQueue` stores waiters in a fixed `[Option<u16>; 64]` slab, **not** a
+`Vec<u16>`. This is mandatory, not an optimization: `notify_all` is called from
+the keyboard ISR, and the global allocator's internal lock (`LockedHeap`) is
+preempt-disable-only, not IRQ-safe. A heap allocation from IRQ context against a
+task-context allocation in progress would deadlock. The fixed cap means no
+`WaitQueue` operation ever allocates. Overflow drops the wake (logged); the caller
+recovers via its deadline timeout or re-poll.
+
+## Lock ordering
+
+When two locks must be held simultaneously, take them in this order. Violating the
+order risks ABBA deadlock across nested acquisitions.
+
+1. `TIMER_QUEUE`
+2. `NET` → `SOCKETS` (network poll path takes NET then SOCKETS; per-socket call
+   sites mirror this)
+3. `WaitQueue.waiters`
+4. `PICS` (always released immediately after EOI; never held across another lock)
+
+`Tty.input_buffer`, `KEY_EVENT_QUEUE`, and `PACKETS` are leaf locks — never held
+while acquiring another lock.
+
+## Scheduling rules
+
+- The kernel is non-preemptive. A task-context critical section can only be
+  interrupted by an external IRQ, never by another task. Preempt-disable
+  (`PreemptGuard`) is therefore about disabling preemption at explicit safe points
+  (`cond_resched`), not about preventing concurrent execution.
+- `lock_irq()` is the only mechanism that prevents IRQ reentrancy. Use it for any
+  IRQ-shared lock (see table above).
+- Context-tracking counters (`HELD_LOCK_COUNT`, `FAULT_CONTEXT`,
+  `ALLOCATOR_CONTEXT`, etc.) are **always active**, even with
+  `ENABLE_KERNEL_PREEMPTION = false`. They back diagnostic assertions
+  (`warn_if_schedule_unsafe`) and document which context a code path runs in.
+  Keeping them active has negligible cost (one atomic op per lock/context) and
+  makes lock-balance bugs observable in the non-preemptive kernel.
+- `can_preempt_kernel()` remains gated on `ENABLE_KERNEL_PREEMPTION`; when false
+  it returns `false` immediately. The counters it consults are now maintained
+  regardless, so enabling kernel preemption later requires no further changes.
+
+## Adding a new lock
+
+1. Determine whether any IRQ handler will acquire it. If yes → `lock_irq()` at
+   **every** site, and add a row to the inventory table.
+2. If the lock is held across another lock acquisition, place it in the ordering
+   list above and verify the order.
+3. If the lock is acquired from an IRQ handler, ensure no operation under it can
+   allocate (or that the allocation is IRQ-safe). The heap lock is not IRQ-safe.
+4. Prefer leaf locks (no nested acquisition). If nesting is unavoidable, document
+   the order here.

--- a/docs/kernel-locking.md
+++ b/docs/kernel-locking.md
@@ -51,9 +51,11 @@ lock at all. This is safe because of two invariants:
 
 Because both accessors have IF off (or are the same context), there is no
 reentrant access. Wrapping every `PROCESS_TABLE.get_mut()` in an `IrqGuard` would
-be redundant noise. The same reasoning applies to `UCHI_DEVICES` and the other
-`Once<T>` / `static mut` structures accessed from both init and IRQ handlers:
-init runs before interrupts are enabled, and the IRQ handler runs with IF off.
+be redundant noise. This conclusion holds **only while syscall handlers keep IF
+cleared**; re-audit `PROCESS_TABLE` before enabling interrupts in syscall bodies.
+The same reasoning applies to `UCHI_DEVICES` and the other `Once<T>` / `static mut`
+structures accessed from both init and IRQ handlers: init runs before interrupts
+are enabled, and the IRQ handler runs with IF off.
 
 ## IRQ-shared lock inventory
 
@@ -115,7 +117,8 @@ while acquiring another lock.
   makes lock-balance bugs observable in the non-preemptive kernel.
 - `can_preempt_kernel()` remains gated on `ENABLE_KERNEL_PREEMPTION`; when false
   it returns `false` immediately. The counters it consults are now maintained
-  regardless, so enabling kernel preemption later requires no further changes.
+  regardless, so future preemption work can reuse them; enabling kernel
+  preemption still requires a separate scheduler and call-site audit.
 
 ## Adding a new lock
 

--- a/kernel/twilight_kernel/src/arch/x86_64/idt.rs
+++ b/kernel/twilight_kernel/src/arch/x86_64/idt.rs
@@ -354,7 +354,7 @@ pub fn register_irq_handler(irq: u8, handler: fn()) -> Result<(), ()> {
 
     // Unmask the IRQ in PIC
     unsafe {
-        let mut pics = PICS.lock();
+        let mut pics = PICS.lock_irq();
         let halves = pics.read_masks();
         let mut masks = (halves[0] as u16) | ((halves[1] as u16) << 8);
         masks &= !(1 << irq);
@@ -372,8 +372,11 @@ pub fn irq_vector(irq: u8) -> u8 {
 }
 
 fn dispatch_irq(irq: u8) {
+    // Account every external IRQ on the depth stack so `irq_depth()` reflects
+    // all in-progress interrupts, not only the timer (#70).
+    let _ctx = crate::arch::x86_64::irq::IrqCtx::new();
     unsafe {
-        PICS.lock().notify_end_of_interrupt(interrupt_index(irq));
+        PICS.lock_irq().notify_end_of_interrupt(interrupt_index(irq));
     }
     if irq < 16 {
         if let Some(h) = { IRQ_HANDLERS.lock()[irq as usize] } {
@@ -384,10 +387,10 @@ fn dispatch_irq(irq: u8) {
 
 pub fn init_pics() {
     unsafe {
-        PICS.lock().initialize();
+        PICS.lock_irq().initialize();
         // PIC1: unmask IRQ0..2 (timer, keyboard, cascade).
         // PIC2: unmask IRQ12 (mouse), IRQ14/15 (IDE).
-        PICS.lock().write_masks(0b11111000, 0b00101111);
+        PICS.lock_irq().write_masks(0b11111000, 0b00101111);
     }
 }
 
@@ -540,12 +543,14 @@ unsafe extern "C" fn apic_timer_preempt_isr() -> ! {
 extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: InterruptStackFrame) {
     use x86_64::instructions::port::Port;
 
+    let _ctx = crate::arch::x86_64::irq::IrqCtx::new();
+
     let mut port = Port::<u8>::new(0x60);
 
     let scancode: u8 = unsafe { port.read() };
 
     unsafe {
-        PICS.lock().notify_end_of_interrupt(interrupt_index(1));
+        PICS.lock_irq().notify_end_of_interrupt(interrupt_index(1));
     }
 
     keyboard_interrupt(scancode);
@@ -554,13 +559,15 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: InterruptStac
 extern "x86-interrupt" fn mouse_interrupt_handler(_stack_frame: InterruptStackFrame) {
     use x86_64::instructions::port::Port;
 
+    let _ctx = crate::arch::x86_64::irq::IrqCtx::new();
+
     let mut port = Port::<u8>::new(0x60);
     let data: u8 = unsafe { port.read() };
 
     handle_interrupt_byte(data);
 
     unsafe {
-        PICS.lock().notify_end_of_interrupt(interrupt_index(12));
+        PICS.lock_irq().notify_end_of_interrupt(interrupt_index(12));
     }
 }
 

--- a/kernel/twilight_kernel/src/arch/x86_64/irq.rs
+++ b/kernel/twilight_kernel/src/arch/x86_64/irq.rs
@@ -1,0 +1,38 @@
+//! Common external-interrupt accounting (#70).
+//!
+//! Every external IRQ vector must bracket its handler body with [`IrqCtx`] so
+//! that `IRQ_DEPTH` reflects *all* in-progress interrupts, not only the timer.
+//! This is load-bearing for two reasons:
+//!
+//! 1. `can_preempt_kernel()` and `warn_if_schedule_unsafe()` consult
+//!    `irq_depth()` to refuse scheduling inside an interrupt. Without
+//!    accounting here, a device IRQ that wakes a process could escape through a
+//!    non-timer path with `irq_depth == 0`, hiding a forbidden-schedule bug.
+//! 2. The follow-up syscall-IRQ ticket needs proof that no external IRQ exits
+//!    through a scheduling path; uniform depth tracking is that evidence.
+//!
+//! `IrqCtx` is allocation-free (a single atomic increment/decrement) and may be
+//! held across the entire handler body including any wake calls.
+
+use crate::sys::preempt;
+
+/// RAII guard that increments `IRQ_DEPTH` on construction and decrements it on
+/// drop. Wrap every external interrupt handler body in `let _ctx = IrqCtx::new();`.
+pub struct IrqCtx {
+    _priv: (),
+}
+
+impl IrqCtx {
+    #[inline]
+    pub fn new() -> Self {
+        preempt::irq_enter();
+        Self { _priv: () }
+    }
+}
+
+impl Drop for IrqCtx {
+    #[inline]
+    fn drop(&mut self) {
+        preempt::irq_exit();
+    }
+}

--- a/kernel/twilight_kernel/src/arch/x86_64/mod.rs
+++ b/kernel/twilight_kernel/src/arch/x86_64/mod.rs
@@ -5,6 +5,7 @@ pub mod cpu_local;
 pub mod gdt;
 pub mod idt;
 pub mod io;
+pub mod irq;
 pub mod power;
 pub mod syscall;
 

--- a/kernel/twilight_kernel/src/driver/keyboard/mod.rs
+++ b/kernel/twilight_kernel/src/driver/keyboard/mod.rs
@@ -168,7 +168,7 @@ struct PendingKeyEvent {
 
 fn enqueue_key_event(event: PcKeyEvent) {
     if let Some(code) = keycode_to_linux(event.code) {
-        let mut queue = KEY_EVENT_QUEUE.lock();
+        let mut queue = KEY_EVENT_QUEUE.lock_irq();
         if queue.len() >= MAX_KEY_EVENTS {
             queue.pop_front();
         }
@@ -292,7 +292,7 @@ pub struct KeyboardDev;
 impl KeyboardDev {
     fn pop_events(&self, capacity: usize) -> Vec<InputEvent> {
         let mut collected = Vec::new();
-        let mut queue = KEY_EVENT_QUEUE.lock();
+        let mut queue = KEY_EVENT_QUEUE.lock_irq();
 
         for _ in 0..capacity {
             if let Some(evt) = queue.pop_front() {
@@ -337,7 +337,7 @@ impl VfsNodeOps for KeyboardDev {
     }
 
     fn poll(&self, _device: &mut BlockDev) -> Result<bool, ()> {
-        Ok(!KEY_EVENT_QUEUE.lock().is_empty())
+        Ok(!KEY_EVENT_QUEUE.lock_irq().is_empty())
     }
 
     fn ioctl(&mut self, _device: &mut BlockDev, _cmd: u64, _arg: usize) -> Result<i64, ()> {
@@ -350,9 +350,9 @@ impl VfsNodeOps for KeyboardDev {
 }
 
 pub fn keyboard_interrupt(scancode: u8) {
-    let mut keyboard = KEYBOARD.lock();
+    let mut keyboard = KEYBOARD.lock_irq();
 
-    let mut ps2_keyboard_state = PS2_KEYBOARD_STATE.lock();
+    let mut ps2_keyboard_state = PS2_KEYBOARD_STATE.lock_irq();
 
     if scancode == 29 {
         ps2_keyboard_state.is_ctrl_pressed = true;

--- a/kernel/twilight_kernel/src/driver/mouse/mod.rs
+++ b/kernel/twilight_kernel/src/driver/mouse/mod.rs
@@ -15,7 +15,7 @@ lazy_static! {
 }
 
 pub(crate) fn enqueue_packet(packet: [u8; PS2_PACKET_SIZE]) {
-    let mut packets = PACKETS.lock();
+    let mut packets = PACKETS.lock_irq();
     if packets.len() == MAX_PACKETS {
         packets.pop_front();
     }
@@ -37,7 +37,7 @@ impl VfsNodeOps for MouseDev {
         }
 
         loop {
-            if let Some(packet) = PACKETS.lock().pop_front() {
+            if let Some(packet) = PACKETS.lock_irq().pop_front() {
                 buf[..PS2_PACKET_SIZE].copy_from_slice(&packet);
                 return Ok(PS2_PACKET_SIZE);
             }
@@ -50,7 +50,7 @@ impl VfsNodeOps for MouseDev {
     }
 
     fn poll(&self, _device: &mut BlockDev) -> Result<bool, ()> {
-        Ok(!PACKETS.lock().is_empty())
+        Ok(!PACKETS.lock_irq().is_empty())
     }
 
     fn ioctl(&mut self, _device: &mut BlockDev, _cmd: u64, _arg: usize) -> Result<i64, ()> {

--- a/kernel/twilight_kernel/src/driver/mouse/ps2.rs
+++ b/kernel/twilight_kernel/src/driver/mouse/ps2.rs
@@ -75,7 +75,7 @@ pub fn init() {
 }
 
 pub fn handle_interrupt_byte(byte: u8) {
-    let mut state = PACKET_STATE.lock();
+    let mut state = PACKET_STATE.lock_irq();
     if let Some(packet) = state.push(byte) {
         enqueue_packet(packet);
     }

--- a/kernel/twilight_kernel/src/main.rs
+++ b/kernel/twilight_kernel/src/main.rs
@@ -269,7 +269,7 @@ pub fn init(
 
     // Mask PIT (IRQ0) to prevent double ticks
     unsafe {
-        let mut pics = arch::x86_64::idt::PICS.lock();
+        let mut pics = arch::x86_64::idt::PICS.lock_irq();
         let masks = pics.read_masks();
         // Preserve all dynamically unmasked IRQs (e.g. UHCI IRQ10) and only mask IRQ0.
         pics.write_masks(masks[0] | 0x01, masks[1]);

--- a/kernel/twilight_kernel/src/sys/console/tty.rs
+++ b/kernel/twilight_kernel/src/sys/console/tty.rs
@@ -195,7 +195,7 @@ impl Tty {
     /// Canonical reads become ready only when a complete line (or VEOF) is
     /// present; this mirrors the readiness rule used by Unix terminals.
     pub fn input_read_ready(&self) -> bool {
-        let input = self.input_buffer.lock();
+        let input = self.input_buffer.lock_irq();
         if self.icanon {
             input
                 .iter()
@@ -237,10 +237,10 @@ impl Tty {
 
     pub fn put_input(&mut self, c: u8) {
         if self.is_raw_mode() && c == b'\x08' {
-            self.input_buffer.lock().push_back(0x7Fu8);
+            self.input_buffer.lock_irq().push_back(0x7Fu8);
             // serial_println!("{:?}", self.input_buffer);
         } else {
-            self.input_buffer.lock().push_back(c);
+            self.input_buffer.lock_irq().push_back(c);
         }
     }
     fn is_raw_mode(&self) -> bool {
@@ -261,7 +261,7 @@ impl Tty {
 
     #[inline]
     fn pop_input_now(&self) -> Option<u8> {
-        self.input_buffer.lock().pop_front()
+        self.input_buffer.lock_irq().pop_front()
     }
 
     #[inline]
@@ -918,7 +918,7 @@ fn xterm_256_to_rgb(n: u8) -> u32 {
 impl KeyboardListener for Tty {
     fn on_key(&self, key: u8, released: bool) {
         if !released {
-            self.input_buffer.lock().push_back(key);
+            self.input_buffer.lock_irq().push_back(key);
             // Wake any processes blocked in pop_input_blocking() and any
             // poller/selecter waiting for readability on this TTY (#69). The
             // global poll queue is notified so a poll(stdin) waiter that is not
@@ -974,7 +974,7 @@ impl VfsNodeOps for Tty {
     }
 
     fn poll(&self, _device: &mut BlockDev) -> Result<bool, ()> {
-        Ok(!self.input_buffer.lock().is_empty())
+        Ok(!self.input_buffer.lock_irq().is_empty())
     }
 
     fn ioctl(&mut self, _device: &mut BlockDev, cmd: u64, arg: usize) -> Result<i64, ()> {
@@ -1014,7 +1014,7 @@ impl VfsNodeOps for Tty {
                 self.termios = newt;
                 self.apply_termios();
                 if cmd == IOCTL_TCSETSF {
-                    self.input_buffer.lock().clear();
+                    self.input_buffer.lock_irq().clear();
                 }
             }
             IOCTL_TIOCGPGRP => {

--- a/kernel/twilight_kernel/src/sys/preempt.rs
+++ b/kernel/twilight_kernel/src/sys/preempt.rs
@@ -24,11 +24,22 @@ static IN_SCHEDULER: AtomicBool = AtomicBool::new(false);
 // `IrqGuard` and `Mutex::lock_irq()` disable interrupts and must be nest-safe:
 // an inner guard's drop must not re-enable interrupts while an outer guard is
 // still alive. We track a depth counter (`IRQ_DISABLE_DEPTH`) that records how
-// many IRQ-disabling guards are stacked on this CPU. A guard increments on
-// construction (after disabling) and decrements on drop; interrupts are
+// many IRQ-disabling guards are stacked on the current CPU. A guard increments
+// on construction (after disabling) and decrements on drop; interrupts are
 // re-enabled only when the depth returns to zero. The outermost guard remembers
 // whether IF was enabled before it disabled, so a guard constructed inside an
 // already-IRQ-off region restores IF=0.
+//
+// LIFO contract: guards must drop in reverse order of construction. Each
+// `irq_restore(was_enabled)` pairs with its `irq_save()`, and the depth only
+// reaches zero when the outermost guard drops; an inner guard dropping while an
+// outer one is still live leaves the depth non-zero, so IF stays cleared.
+//
+// This counter is currently a single global, not per-CPU. That is correct only
+// because APs do not enter these paths: `ap_main` loads no IDT and sits in a
+// halt loop, so it never acquires `lock_irq()`/`IrqGuard` or takes interrupts
+// (same invariant documented above for `PREEMPT_COUNT`). Moving scheduling onto
+// APs requires making this `CpuLocal` first — see the note on GS reuse above.
 static IRQ_DISABLE_DEPTH: AtomicUsize = AtomicUsize::new(0);
 
 static NEED_RESCHED: AtomicBool = AtomicBool::new(false);
@@ -237,7 +248,10 @@ pub fn irq_save() -> bool {
 /// them; otherwise leave interrupts disabled (an outer guard still owns the
 /// IRQ-off region).
 ///
-/// `was_enabled` must be the value returned by the paired [`irq_save`].
+/// `was_enabled` must be the value returned by the paired [`irq_save`], and
+/// calls must be LIFO: an inner guard must drop before its enclosing outer
+/// guard. The depth only reaches zero when the outermost guard drops, so a
+/// well-ordered drop sequence never re-enables IF while an outer guard is live.
 #[inline]
 pub fn irq_restore(was_enabled: bool) {
     if let Some(0) = decrement(&IRQ_DISABLE_DEPTH, "irq_disable_depth") {

--- a/kernel/twilight_kernel/src/sys/preempt.rs
+++ b/kernel/twilight_kernel/src/sys/preempt.rs
@@ -19,6 +19,18 @@ static IRQ_DEPTH: AtomicUsize = AtomicUsize::new(0);
 
 static IN_SCHEDULER: AtomicBool = AtomicBool::new(false);
 
+// --- Nest-safe interrupt masking (#70) -------------------------------------
+//
+// `IrqGuard` and `Mutex::lock_irq()` disable interrupts and must be nest-safe:
+// an inner guard's drop must not re-enable interrupts while an outer guard is
+// still alive. We track a depth counter (`IRQ_DISABLE_DEPTH`) that records how
+// many IRQ-disabling guards are stacked on this CPU. A guard increments on
+// construction (after disabling) and decrements on drop; interrupts are
+// re-enabled only when the depth returns to zero. The outermost guard remembers
+// whether IF was enabled before it disabled, so a guard constructed inside an
+// already-IRQ-off region restores IF=0.
+static IRQ_DISABLE_DEPTH: AtomicUsize = AtomicUsize::new(0);
+
 static NEED_RESCHED: AtomicBool = AtomicBool::new(false);
 
 // --- Scheduler quantum (one-shot clockevent, #68) --------------------------
@@ -38,9 +50,11 @@ static QUANTUM_DEADLINE: AtomicU64 = AtomicU64::new(0);
 
 // --- Kernel-preemption context trackers -----------------------------------
 //
-// These counters are only incremented when `ENABLE_KERNEL_PREEMPTION` is true
-// (a compile-time const). When the flag is false the compiler eliminates every
-// increment/decrement, so existing behavior is preserved with zero overhead.
+// These counters are always incremented (regardless of
+// `ENABLE_KERNEL_PREEMPTION`) so that lock-balance and context-invariant
+// diagnostics work in the non-preemptive kernel too (#70). The cost is one
+// atomic op per lock acquire/release and context enter/exit — negligible beside
+// the spinlock acquire itself.
 //
 // Each counter is a depth (not a boolean) so that nested entry is balanced.
 // `can_preempt_kernel()` requires every counter to be zero before scheduling
@@ -200,6 +214,39 @@ pub fn irq_depth() -> usize {
     IRQ_DEPTH.load(Ordering::SeqCst)
 }
 
+// --- Nest-safe IRQ disable/restore (#70) -----------------------------------
+
+/// Disable interrupts and record this IRQ-off region on the per-CPU depth
+/// stack. Returns `true` if interrupts were enabled before the call (so the
+/// outermost guard is responsible for re-enabling them). Pairs with
+/// [`irq_restore`].
+///
+/// Nest-safe: an inner call made while interrupts are already off still
+/// increments the depth but records `was_enabled = false`, so its matching
+/// [`irq_restore`] will not re-enable interrupts prematurely.
+#[inline]
+pub fn irq_save() -> bool {
+    let was_enabled = x86_64::instructions::interrupts::are_enabled();
+    x86_64::instructions::interrupts::disable();
+    IRQ_DISABLE_DEPTH.fetch_add(1, Ordering::SeqCst);
+    was_enabled
+}
+
+/// Pop one level off the IRQ-disable depth stack. When the depth returns to
+/// zero and the matching [`irq_save`] observed interrupts enabled, re-enable
+/// them; otherwise leave interrupts disabled (an outer guard still owns the
+/// IRQ-off region).
+///
+/// `was_enabled` must be the value returned by the paired [`irq_save`].
+#[inline]
+pub fn irq_restore(was_enabled: bool) {
+    if let Some(0) = decrement(&IRQ_DISABLE_DEPTH, "irq_disable_depth") {
+        if was_enabled {
+            x86_64::instructions::interrupts::enable();
+        }
+    }
+}
+
 #[inline]
 pub fn set_need_resched() {
     let was_set = NEED_RESCHED.swap(true, Ordering::SeqCst);
@@ -265,16 +312,12 @@ pub fn in_scheduler() -> bool {
 
 #[inline]
 pub fn lock_count_inc() {
-    if ENABLE_KERNEL_PREEMPTION {
-        HELD_LOCK_COUNT.fetch_add(1, Ordering::SeqCst);
-    }
+    HELD_LOCK_COUNT.fetch_add(1, Ordering::SeqCst);
 }
 
 #[inline]
 pub fn lock_count_dec() {
-    if ENABLE_KERNEL_PREEMPTION {
-        decrement(&HELD_LOCK_COUNT, "held_lock_count");
-    }
+    decrement(&HELD_LOCK_COUNT, "held_lock_count");
 }
 
 #[inline]
@@ -290,8 +333,8 @@ pub fn locks_held() -> bool {
 // --- Context guards -------------------------------------------------------
 
 /// RAII guard that increments a context counter on creation and decrements it
-/// on drop. When `ENABLE_KERNEL_PREEMPTION` is false the increment/decrement
-/// are compile-time eliminated, so the guard is zero-cost.
+/// on drop. The counters are always active so diagnostics work in the
+/// non-preemptive kernel too (#70).
 #[must_use = "dropping the guard exits the context"]
 pub struct ContextGuard {
     counter: &'static AtomicUsize,
@@ -301,9 +344,7 @@ pub struct ContextGuard {
 
 impl ContextGuard {
     fn enter(counter: &'static AtomicUsize, name: &'static str) -> Self {
-        if ENABLE_KERNEL_PREEMPTION {
-            counter.fetch_add(1, Ordering::SeqCst);
-        }
+        counter.fetch_add(1, Ordering::SeqCst);
         Self {
             counter,
             name,
@@ -316,9 +357,7 @@ impl Drop for ContextGuard {
     fn drop(&mut self) {
         if self.active {
             self.active = false;
-            if ENABLE_KERNEL_PREEMPTION {
-                decrement(self.counter, self.name);
-            }
+            decrement(self.counter, self.name);
         }
     }
 }
@@ -483,7 +522,7 @@ pub fn warn_if_schedule_unsafe() {
         );
     }
     if in_fault_context() {
-        // crate::serial_println!("[sched] WARNING: schedule_now inside fault context");
+        crate::serial_println!("[sched] WARNING: schedule_now inside fault context");
     }
     if in_allocator_context() {
         crate::serial_println!("[sched] WARNING: schedule_now inside allocator context");

--- a/kernel/twilight_kernel/src/sys/proc/mod.rs
+++ b/kernel/twilight_kernel/src/sys/proc/mod.rs
@@ -2353,7 +2353,7 @@ pub extern "C" fn timer_preempt(frame: *mut PreemptFrame, from_user: u64) -> *mu
     // EOI for IRQ0 (PIC timer)
     unsafe {
         crate::arch::x86_64::idt::PICS
-            .lock()
+            .lock_irq()
             .notify_end_of_interrupt(crate::arch::x86_64::idt::PIC_1_OFFSET);
     }
 

--- a/kernel/twilight_kernel/src/utils/sync.rs
+++ b/kernel/twilight_kernel/src/utils/sync.rs
@@ -1,6 +1,4 @@
-use alloc::vec::Vec;
 use core::mem::ManuallyDrop;
-use x86_64::instructions::interrupts;
 
 use crate::sys::preempt::PreemptGuard;
 
@@ -24,22 +22,27 @@ impl<T: ?Sized> Mutex<T> {
         crate::sys::preempt::lock_count_inc();
         MutexGuard {
             guard: ManuallyDrop::new(guard),
-            irq_lock: false,
+            irq_was_enabled: false,
+            owns_irq_disable: false,
             _preempt_guard: preempt_guard,
         }
     }
 
     pub fn lock_irq(&self) -> MutexGuard<T> {
-        let irq_lock = interrupts::are_enabled();
-
-        interrupts::disable();
+        // Nest-safe IRQ disable (#70): record whether IF was on, then CLI and
+        // push one level onto the per-CPU IRQ-disable depth stack. The guard's
+        // drop pops the level and re-enables IRQs only when the stack is empty
+        // and IF was originally on — so nested lock_irq()/IrqGuard cannot
+        // prematurely re-enable interrupts.
+        let was_enabled = crate::sys::preempt::irq_save();
         let preempt_guard = PreemptGuard::new_no_resched();
         let guard = self.inner.lock();
         crate::sys::preempt::lock_count_inc();
 
         MutexGuard {
             guard: ManuallyDrop::new(guard),
-            irq_lock,
+            irq_was_enabled: was_enabled,
+            owns_irq_disable: true,
             _preempt_guard: preempt_guard,
         }
     }
@@ -51,7 +54,13 @@ impl<T: ?Sized> Mutex<T> {
 
 pub struct MutexGuard<'a, T: ?Sized + 'a> {
     guard: ManuallyDrop<spin::MutexGuard<'a, T>>,
-    irq_lock: bool,
+    /// Whether IF was enabled when `lock_irq()` was called. Only meaningful
+    /// when `owns_irq_disable` is true.
+    irq_was_enabled: bool,
+    /// True iff this guard was produced by `lock_irq()` and therefore owns one
+    /// level on the IRQ-disable depth stack that must be popped on drop.
+    /// `lock()` sets this false and never touches IRQ state.
+    owns_irq_disable: bool,
     // Dropped after Drop::drop releases the spinlock and restores IRQ state.
     _preempt_guard: PreemptGuard,
 }
@@ -75,13 +84,18 @@ impl<T: ?Sized> core::ops::DerefMut for MutexGuard<'_, T> {
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
+        // Release the spinlock first, then pop the IRQ-disable depth stack (if
+        // this was a lock_irq guard) so IRQs are not re-enabled while the lock
+        // is still held.
+        let owns_irq = self.owns_irq_disable;
+        let was_enabled = self.irq_was_enabled;
         unsafe {
             ManuallyDrop::drop(&mut self.guard);
         }
         crate::sys::preempt::lock_count_dec();
 
-        if self.irq_lock {
-            interrupts::enable();
+        if owns_irq {
+            crate::sys::preempt::irq_restore(was_enabled);
         }
     }
 }
@@ -175,39 +189,56 @@ impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
     }
 }
 
+/// RAII guard that disables interrupts for its lifetime and restores the
+/// previous interrupt state on drop.
+///
+/// Nest-safe (#70): an `IrqGuard` constructed while another `IrqGuard` (or a
+/// `Mutex::lock_irq()` guard) is already live will not re-enable interrupts on
+/// drop; only the outermost guard (the one that observed IF enabled) restores
+/// interrupts. This is backed by a per-CPU depth counter in
+/// [`crate::sys::preempt`].
 pub struct IrqGuard {
-    locked: bool,
+    was_enabled: bool,
 }
 
 impl IrqGuard {
-    /// Creates a new IRQ guard. See the [`IrqGuard`] documentation for more.
+    /// Disable interrupts and push one level onto the IRQ-disable depth stack.
     pub fn new() -> Self {
-        let locked = interrupts::are_enabled();
-
-        interrupts::disable();
-
-        Self { locked }
+        let was_enabled = crate::sys::preempt::irq_save();
+        Self { was_enabled }
     }
 }
 
 impl Drop for IrqGuard {
-    /// Drops the IRQ guard, enabling interrupts again. See the [`IrqGuard`]
-    /// documentation for more.
     fn drop(&mut self) {
-        if self.locked {
-            interrupts::enable();
-        }
+        crate::sys::preempt::irq_restore(self.was_enabled);
     }
 }
 
+/// Maximum number of waiters a single [`WaitQueue`] can hold.
+///
+/// This is a fixed cap so the queue never heap-allocates — critical because
+/// `notify_all` is invoked from IRQ context (keyboard ISR), where the global
+/// allocator's internal spin lock is not IRQ-safe and could deadlock against a
+/// task-context allocation in progress (#70). A wait queue's waiter count is
+/// bounded by the number of live processes blocked on the same resource, which
+/// in practice is far below this cap; overflow drops the wake (the caller will
+/// retry or the waiter times out), never corrupts state.
+const WAIT_QUEUE_CAPACITY: usize = 64;
+
+/// A blocking-wait queue storing PIDs in a fixed-size slab.
+///
+/// All operations are O(n) in the waiter count (n ≤ [`WAIT_QUEUE_CAPACITY`]),
+/// which is acceptable for the small waiter sets this serves. The slab is
+/// allocation-free so it is safe to drive from IRQ context.
 pub struct WaitQueue {
-    waiters: Mutex<Vec<u16>>,
+    waiters: Mutex<[Option<u16>; WAIT_QUEUE_CAPACITY]>,
 }
 
 impl WaitQueue {
     pub const fn new() -> Self {
         Self {
-            waiters: Mutex::new(Vec::new()),
+            waiters: Mutex::new([const { None }; WAIT_QUEUE_CAPACITY]),
         }
     }
 
@@ -215,29 +246,39 @@ impl WaitQueue {
         let pid = crate::sys::proc::id();
         let mut waiters = self.waiters.lock_irq();
 
-        if !waiters.contains(&pid) {
-            waiters.push(pid);
+        // Already queued?
+        if waiters.iter().any(|w| matches!(w, Some(p) if *p == pid)) {
+            return pid;
         }
-
+        for slot in waiters.iter_mut() {
+            if slot.is_none() {
+                *slot = Some(pid);
+                return pid;
+            }
+        }
+        // Slab full: leave unqueued. The caller still blocks via its deadline /
+        // spurious-wake path; the worst case is a missed wake that the caller's
+        // timeout or re-poll recovers from. Log so overflow is observable.
+        crate::serial_println!("[WaitQueue] prepare_current: slab full ({}), pid={} not enqueued", WAIT_QUEUE_CAPACITY, pid);
         pid
     }
 
     pub fn finish_wait(&self, pid: u16) {
         let mut waiters = self.waiters.lock_irq();
-
-        if let Some(idx) = waiters.iter().position(|&waiter| waiter == pid) {
-            waiters.remove(idx);
+        for slot in waiters.iter_mut() {
+            if matches!(slot, Some(p) if *p == pid) {
+                *slot = None;
+                break;
+            }
         }
     }
 
     pub fn notify_one(&self) {
         let waiter = {
             let mut waiters = self.waiters.lock_irq();
-            if waiters.is_empty() {
-                None
-            } else {
-                Some(waiters.remove(0))
-            }
+            // Take the first occupied slot.
+            let taken = waiters.iter_mut().find_map(|slot| slot.take());
+            taken
         };
 
         if let Some(pid) = waiter {
@@ -249,11 +290,8 @@ impl WaitQueue {
         loop {
             let waiter = {
                 let mut waiters = self.waiters.lock_irq();
-                if waiters.is_empty() {
-                    None
-                } else {
-                    Some(waiters.remove(0))
-                }
+                let taken = waiters.iter_mut().find_map(|slot| slot.take());
+                taken
             };
 
             let Some(pid) = waiter else {
@@ -265,7 +303,7 @@ impl WaitQueue {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.waiters.lock_irq().is_empty()
+        self.waiters.lock_irq().iter().all(|w| w.is_none())
     }
 }
 


### PR DESCRIPTION
Closes #70.

## Summary

The kernel is single-CPU and non-preemptive, so the only deadlock hazard is a task-context lock holder (interrupts on) interrupted by an IRQ handler that acquires the same lock. Any lock ever taken from an IRQ handler must use `lock_irq()` at **every** site — a single plain `lock()` on an IRQ-shared lock is a live deadlock.

This PR audits every IRQ-shared lock, fixes the live deadlocks found, and documents the contracts for locks that are *not* IRQ-shared.

## Changes

### Nest-safe IRQ disable (`sys/preempt.rs`, `utils/sync.rs`)
- `preempt::irq_save()` / `irq_restore()` backed by an `IRQ_DISABLE_DEPTH` counter.
- `Mutex::lock_irq()` and `IrqGuard` route through it. Nested guards no longer prematurely re-enable interrupts.
- `MutexGuard` now carries `owns_irq_disable` + `irq_was_enabled` to distinguish `lock()` from `lock_irq()` guards.

### Uniform IRQ accounting (`arch/x86_64/irq.rs`, new)
- New `IrqCtx` guard (`irq_enter`/`irq_exit`). All external IRQ handlers wrapped: `dispatch_irq`, `keyboard_interrupt_handler`, `mouse_interrupt_handler`.

### Live deadlock fixes — converted to `lock_irq()`
- **`Tty.input_buffer`** (7 sites) — acquired from keyboard ISR + UART IRQ4 **and** task-context reads. Real deadlock today.
- **`KEY_EVENT_QUEUE`**, **`PACKETS`** (mouse) — both IRQ-shared.
- **`PICS`** at all remaining sites (init, EOI paths).
- **`KEYBOARD`** / **`PS2_KEYBOARD_STATE`** / **`PACKET_STATE`** — IRQ-context-only, converted for contract consistency.

### Allocation-free WaitQueue (`utils/sync.rs`)
- Fixed `[Option<u16>; 64]` slab instead of `Vec<u16>`. Mandatory: `notify_all` runs from keyboard ISR and the heap lock is preempt-disable-only (not IRQ-safe), so heap allocation from IRQ context would deadlock.

### Always-on diagnostics (`sys/preempt.rs`)
- `HELD_LOCK_COUNT` and `ContextGuard` inc/dec no longer gated on `ENABLE_KERNEL_PREEMPTION`.
- Uncommented `in_fault_context` schedule warning.

### Documentation (`docs/kernel-locking.md`)
Full lock inventory, ordering graph, scheduling rules. Documents why `NET`/`SOCKETS` (polled only, not IRQ-shared) and `PROCESS_TABLE` (IF off via `IA32_FMASK=0x300`) need no changes.

## Build
Clean, zero warnings.

## Test plan
- [x] Kernel builds clean with no warnings
- [ ] Boot under QEMU, verify keyboard input (exercises `Tty.input_buffer` + `KEY_EVENT_QUEUE` from ISR and task context)
- [ ] Verify mouse input (`PACKETS`)
- [ ] Verify serial console input (UART IRQ4 → `input_buffer`)
- [ ] Verify `nanosleep`/`poll` timeout wake paths (`WaitQueue.notify_*` from IRQ context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved interrupt handling across keyboard, mouse, timer, console, and device operations.
  * Added nest-safe interrupt state management to prevent incorrect interrupt restoration.
  * Improved tracking of active interrupt handling and scheduling diagnostics.

* **Performance & Stability**
  * Wait queues now use fixed, allocation-free storage with overflow reporting.
  * Strengthened synchronization for interrupt-driven input and hardware events.

* **Documentation**
  * Added kernel locking guidance covering interrupt safety, lock ordering, wait queues, and scheduling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->